### PR TITLE
#5:  Tired of syncing tickets

### DIFF
--- a/gbe/management/commands/sync_bpt_transactions.py
+++ b/gbe/management/commands/sync_bpt_transactions.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand, CommandError
+from gbe_logging import logger
+from ticketing.brown_paper import process_bpt_order_list
+
+
+class Command(BaseCommand):
+    help = '''Imports any new transactions for known BPT purchases'''
+
+    def handle(self, *args, **options):
+        logger.info('Executing SyncBPTTrans Script....')
+        self.stdout.write('Executing SyncBPTTrans Script....')
+        count = process_bpt_order_list()
+        logger.info('%s transactions imported.' % count)
+        self.stdout.write('%s transactions imported.' % count)


### PR DESCRIPTION
Added the ticket sync as a manage.py command.  So much easier to integrate with cron and makes all our commands consistent.

Doing an out of band push of this branch to the live site, because it's hard to reliably test on my local.