### PR TITLE
#27: Fix style on <hr> in custom styles

### DIFF
--- a/static/styles/gbe_bootstrap.min.css
+++ b/static/styles/gbe_bootstrap.min.css
@@ -322,7 +322,7 @@ a:focus{outline:-webkit-focus-ring-color auto 5px;outline-offset:-2px}
 .img-rounded{border-radius:6px}
 .img-thumbnail{border:0px;-webkit-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out;display:inline-block;max-width:100%;height:auto}
 .img-circle{border-radius:50%}
-hr{margin-top:20px;margin-bottom:20px;border:0;border-top:1px solid #eee}
+hr{margin-top:20px;margin-bottom:20px;border:0;border-top:1px solid #333}
 .sr-only{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);border:0}
 .sr-only-focusable:active,.sr-only-focusable:focus{position:static;width:auto;height:auto;margin:0;overflow:visible;clip:auto}
 [role=button]{cursor:pointer}


### PR DESCRIPTION
#27 was easy to fix - the GBE styles make the <hr> tag very light grey... making it impossible to see on our screens.

Not sure why I did that??  Fixed to make it black (#333)

