### PR TITLE
Gbediv 19.4: Update volunteer opportunity staff management

### DIFF
--- a/gbe/scheduling/views/copy_collections_view.py
+++ b/gbe/scheduling/views/copy_collections_view.py
@@ -178,17 +178,13 @@ class CopyCollectionsView(View):
                 target_day = context['pick_day'].cleaned_data[
                     'copy_to_day']
                 delta = target_day.day - self.start_day
-                response = self.copy_event(
-                    self.occurrence,
+                new_root = self.copy_root(
+                    request,
                     delta,
                     target_day.conference,
-                    context['pick_day'].cleaned_data['room'],
-                    set_room=True)
-                show_scheduling_occurrence_status(
-                    request,
-                    response,
-                    self.__class__.__name__)
-                if response.occurrence:
+                    context['pick_day'].cleaned_data['room'])
+
+                if new_root:
                     slug = target_day.conference.conference_slug
                     return HttpResponseRedirect(
                         "%s?%s-day=%d&filter=Filter&new=%s" % (
@@ -197,7 +193,7 @@ class CopyCollectionsView(View):
                                     args=[slug]),
                             slug,
                             target_day.pk,
-                            str([response.occurrence.pk]),))
+                            str([new_root.pk]),))
         if 'pick_event' in request.POST.keys():
             return self.copy_events_from_form(request)
         return render(

--- a/gbe/scheduling/views/copy_occurrence_view.py
+++ b/gbe/scheduling/views/copy_occurrence_view.py
@@ -102,7 +102,8 @@ class CopyOccurrenceView(CopyCollectionsView):
             self.occurrence,
             delta,
             conference,
-            room)
+            room,
+            set_room=True)
         show_scheduling_occurrence_status(
             request,
             response,

--- a/gbe/scheduling/views/copy_staff_area_view.py
+++ b/gbe/scheduling/views/copy_staff_area_view.py
@@ -79,7 +79,8 @@ class CopyStaffAreaView(CopyCollectionsView):
         new_area_room = room
         new_title = self.area.title
         new_slug = self.area.slug
-        if conference == self.area.conference:
+        if conference == self.area.conference or StaffArea.objects.filter(
+                conference=conference, title=self.area.title):
             now = datetime.now().strftime(GBE_DATETIME_FORMAT)
             new_title = "%s - New - %s" % (
                 self.area.title,

--- a/gbe/scheduling/views/manage_worker_view.py
+++ b/gbe/scheduling/views/manage_worker_view.py
@@ -100,7 +100,7 @@ class ManageWorkerView(View):
             else:
                 try:
                     forms.append((
-                        role_commit_map[person.role], 
+                        role_commit_map[person.role],
                         WorkerAllocationForm(
                             initial={
                                 'worker': Profile.objects.get(
@@ -111,10 +111,10 @@ class ManageWorkerView(View):
                 except Profile.DoesNotExist:
                     pass
         if errorcontext and 'new_worker_alloc_form' in errorcontext:
-            forms.append((role_commit_map['Error'], 
+            forms.append((role_commit_map['Error'],
                           errorcontext['new_worker_alloc_form']))
         else:
-            forms.append((role_commit_map['New'], 
+            forms.append((role_commit_map['New'],
                           WorkerAllocationForm(initial={'role': 'Volunteer',
                                                         'alloc_id': -1})))
         forms.sort(key=lambda tup: tup[0][0])

--- a/gbe/scheduling/views/manage_worker_view.py
+++ b/gbe/scheduling/views/manage_worker_view.py
@@ -20,7 +20,10 @@ from gbe.models import (
     UserMessage,
 )
 from gbe.email.functions import send_schedule_update_mail
-from gbetext import volunteer_allocate_email_fail_msg
+from gbetext import (
+    role_commit_map,
+    volunteer_allocate_email_fail_msg,
+)
 from gbe.scheduling.forms import WorkerAllocationForm
 from gbe.scheduling.views.functions import show_scheduling_booking_status
 from gbe_forms_text import rank_interest_options
@@ -88,24 +91,31 @@ class ManageWorkerView(View):
                     'worker_alloc_forms' in errorcontext and
                     errorcontext['worker_alloc_forms'].cleaned_data[
                         'alloc_id'] == person.booking_id):
-                forms.append(errorcontext['worker_alloc_forms'])
+                forms.append((role_commit_map['Error'],
+                              errorcontext['worker_alloc_forms']))
             else:
                 try:
-                    forms.append(WorkerAllocationForm(
-                        initial={
-                            'worker': Profile.objects.get(pk=person.public_id),
-                            'role': person.role,
-                            'label': person.label,
-                            'alloc_id': person.booking_id}))
+                    forms.append((
+                        role_commit_map[person.role], 
+                        WorkerAllocationForm(
+                            initial={
+                                'worker': Profile.objects.get(
+                                    pk=person.public_id),
+                                'role': person.role,
+                                'label': person.label,
+                                'alloc_id': person.booking_id})))
                 except Profile.DoesNotExist:
                     pass
         if errorcontext and 'new_worker_alloc_form' in errorcontext:
-            forms.append(errorcontext['new_worker_alloc_form'])
+            forms.append((role_commit_map['Error'], 
+                          errorcontext['new_worker_alloc_form']))
         else:
-            forms.append(WorkerAllocationForm(initial={'role': 'Volunteer',
-                                                       'alloc_id': -1}))
+            forms.append((role_commit_map['New'], 
+                          WorkerAllocationForm(initial={'role': 'Volunteer',
+                                                        'alloc_id': -1})))
+        forms.sort(key=lambda tup: tup[0][0])
         return {'worker_alloc_forms': forms,
-                'worker_alloc_headers': ['Worker', 'Role', 'Notes'],
+                'worker_alloc_headers': ['State', 'Worker', 'Role', 'Notes'],
                 'manage_worker_url': self.manage_worker_url}
 
     def make_post_response(self,

--- a/gbe/templates/gbe/scheduling/allocate_volunteers.tmpl
+++ b/gbe/templates/gbe/scheduling/allocate_volunteers.tmpl
@@ -19,11 +19,12 @@ included in event edit flow. Show WorkerAllocationForms
     {% endfor %}
       <th>Action</th>
     </tr>
-    {% for form in worker_alloc_forms %}
+    {% for role_commit, form in worker_alloc_forms %}
     <tr class="{% if changed_id == form.alloc_id.value %}changed{% else %}event_opp_row{% endif %}">
       <form method="POST" action="{{manage_worker_url}}" 
       	    enctype="multipart/form-data">
         {% csrf_token %}
+    <td>&nbsp;<i class="{{role_commit.1}}"></i></td>
 	{% for field in form.visible_fields %}
 	  <td>
             {{ field }}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -60,7 +60,7 @@
       <input type="submit" class="btn btn-primary" name="filter" value="Filter"></form>
    {% if conference.status != "completed" %}
       <a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn btn-primary">Create</a>
-   </div>{% endif %}</div>
+   {% endif %}</div></div>
    Yellow = volunteers must be approved.
    <div class="row"><div class="col-12">&nbsp;</div></div>
 {% if occurrences %}

--- a/gbetext.py
+++ b/gbetext.py
@@ -281,6 +281,21 @@ role_options = (
     ('Rejected', "Rejected"),
     ('Waitlisted', "Waitlisted"),
     ('Pending Volunteer', "Pending Volunteer"),)
+role_commit_map = {
+    'New': (5, "fas fa-plus-square text-secondary"),
+    'Error': (0, "fas fa-exclamation-triangle text-warning"),
+    'Interested': (1, "fas fa-check-circle text-success"),
+    'Moderator': (1, "fas fa-check-circle text-success"),
+    'Panelist': (1, "fas fa-check-circle text-success"),
+    'Performer': (1, "fas fa-check-circle text-success"),
+    'Producer': (1, "fas fa-check-circle text-success"),
+    'Staff Lead': (1, "fas fa-check-circle text-success"),
+    'Teacher': (1, "fas fa-check-circle text-success"),
+    'Technical Director': (1, "fas fa-check-circle text-success"),
+    'Volunteer': (1, "fas fa-check-circle text-success"),
+    'Rejected': (4, "fas fa-window-close text-danger"),
+    'Waitlisted': (2, "fas fa-clock text-info"),
+    'Pending Volunteer': (3, "fas fa-hourglass-half text-info")}
 not_scheduled_roles = ["Pending Volunteer", "Waitlisted", "Rejected"]
 volunteer_action_map = {
   'approve': {'role': "Volunteer", 'state': 3},

--- a/requirements.in
+++ b/requirements.in
@@ -40,3 +40,5 @@ faker==3.0.1
 zipp==1.0.0
 importlib-metadata==1.4.0
 setuptools==44.0.0
+aldryn-snake==1.0.0
+

--- a/requirements.in
+++ b/requirements.in
@@ -38,3 +38,5 @@ pillow==6.2.1
 tablib==0.14.0
 faker==3.0.1
 zipp==1.0.0
+importlib-metadata==1.4.0
+setuptools==44.0.0

--- a/scheduler/idd/__init__.py
+++ b/scheduler/idd/__init__.py
@@ -10,7 +10,6 @@ from get_bookings import get_bookings
 from get_all_container_bookings import get_all_container_bookings
 from get_people import get_people
 from get_roles import get_roles
-from get_conflicts import get_conflicts
 from get_schedule import get_schedule
 from get_eval_summary import get_eval_summary
 from get_eval_info import get_eval_info

--- a/tests/gbe/scheduling/test_manage_worker.py
+++ b/tests/gbe/scheduling/test_manage_worker.py
@@ -22,7 +22,10 @@ from tests.functions.gbe_functions import (
 from django.shortcuts import get_object_or_404
 from gbe.models import Volunteer
 from django.contrib.sites.models import Site
-from gbetext import volunteer_allocate_email_fail_msg
+from gbetext import (
+    role_commit_map,
+    volunteer_allocate_email_fail_msg,
+)
 from django.core import mail
 
 
@@ -88,6 +91,7 @@ class TestManageWorker(TestCase):
                             role,
                             role,
                             True)
+
         self.assertContains(
             response,
             '<input type="hidden" name="alloc_id" value="' +
@@ -129,6 +133,7 @@ class TestManageWorker(TestCase):
                                   role,
                                   allocations,)
         self.assertNotContains(response, '<ul class="errorlist">')
+        self.assertContains(response, role_commit_map[role][1])
 
     def test_no_login_gives_error(self):
         response = self.client.get(self.url, follow=True)
@@ -243,6 +248,7 @@ class TestManageWorker(TestCase):
             response,
             '<li>Ensure this value has at most 100 characters ' +
             '(it has ' + str(len(big_label)) + ').</li>')
+        self.assertContains(response, role_commit_map['Error'][1])
 
     def test_post_form_edit_bad_role(self):
         data = self.get_edit_data()
@@ -260,6 +266,7 @@ class TestManageWorker(TestCase):
         self.assertContains(
             response,
             '<li>This field is required.</li>')
+        self.assertContains(response, role_commit_map['Error'][1])
 
     def test_post_form_edit_bad_role_and_booking(self):
         data = self.get_edit_data()
@@ -303,6 +310,7 @@ class TestManageWorker(TestCase):
             response,
             '<a href="#" data-toggle="tooltip" title="Create New">',
             count=1)
+        self.assertContains(response, role_commit_map['Error'][1])
 
     def test_post_form_valid_delete_allocation(self):
         data = self.get_edit_data()
@@ -332,6 +340,7 @@ class TestManageWorker(TestCase):
                 urlconf='gbe.scheduling.urls',
                 args=[self.context.conference.conference_slug,
                       self.volunteer_opp.pk])))
+        self.assertContains(response, role_commit_map['New'][1])
 
     def test_post_form_valid_delete_allocation_sends_notification(self):
         data = self.get_edit_data()

--- a/tests/gbe/scheduling/test_manage_worker.py
+++ b/tests/gbe/scheduling/test_manage_worker.py
@@ -227,6 +227,42 @@ class TestManageWorker(TestCase):
             'Do these notes work?',
             "Producer")
 
+    def test_post_form_edit_to_waitlisted(self):
+        new_volunteer = ProfileFactory()
+        data = self.get_edit_data()
+        data['worker'] = new_volunteer.pk,
+        data['role'] = 'Waitlisted',
+
+        login_as(self.privileged_profile, self)
+        response = self.client.post(self.url, data=data, follow=True)
+        self.assert_good_post(
+            response,
+            self.volunteer_opp,
+            new_volunteer,
+            self.alloc,
+            'Do these notes work?',
+            "Waitlisted")
+        assert_email_template_used(
+            "Your volunteer proposal has changed status to Wait List")
+
+    def test_post_form_edit_to_waitlisted(self):
+        new_volunteer = ProfileFactory()
+        data = self.get_edit_data()
+        data['worker'] = new_volunteer.pk,
+        data['role'] = 'Rejected',
+
+        login_as(self.privileged_profile, self)
+        response = self.client.post(self.url, data=data, follow=True)
+        self.assert_good_post(
+            response,
+            self.volunteer_opp,
+            new_volunteer,
+            self.alloc,
+            'Do these notes work?',
+            "Rejected")
+        assert_email_template_used(
+            "Your volunteer proposal has changed status to Reject")
+
     def test_post_form_edit_bad_label(self):
         big_label = 'Do these notes work?Do these notes work?' + \
                     'Do these notes work?Do these notes work?' + \

--- a/tests/gbe/scheduling/test_manage_worker.py
+++ b/tests/gbe/scheduling/test_manage_worker.py
@@ -245,7 +245,7 @@ class TestManageWorker(TestCase):
         assert_email_template_used(
             "Your volunteer proposal has changed status to Wait List")
 
-    def test_post_form_edit_to_waitlisted(self):
+    def test_post_form_edit_to_rejected(self):
         new_volunteer = ProfileFactory()
         data = self.get_edit_data()
         data['worker'] = new_volunteer.pk,


### PR DESCRIPTION
There's a list of staff affiliated with the event when the event is a volunteer opportunity.

Updated:
- to sort by commitment level - first is actual roles doing something at the event (volunteer, teacher, panelist, etc), then waitlisted, then pending, then rejected
- to show an icon connected to commitment level - green check (actually doing something), yellow "!" (error), blue hourglass or clock (waitlist or pending), red x (rejected), and a grey + for new. 
- to send a "proposal rejected/waitlisted" when that's the status we send.  Not a schedule update mail.  That lines up with the way the approve pending volunteers works.

 Deployed on test server if @burlexpo wants to play with it.

I accidentally fixed #54 here, too.  Meant to do it on a separate branch, but was juggling branches and used the wrong one.  Since it was quick to fix, and annoying to unmerge... I left it and added the proper tests.