### PR TITLE
1 line fix - make email everyone form work

### DIFF
--- a/gbe/templates/gbe/email/mail_to_group.tmpl
+++ b/gbe/templates/gbe/email/mail_to_group.tmpl
@@ -38,7 +38,6 @@
 </div>
 {% if email_form %}
 <form action="" method="post" enctype="multipart/form-data"> 
-
 <div class="panel panel-primary">
   <div class="panel-heading">
     <h3 class="panel-title">Send Email</h3>
@@ -48,6 +47,7 @@
     {{ group_filter_note | safe }}<br/><br/>{% endif %}
       {% include "form_table_wrapper.tmpl" with forms=recipient_info %}
       {% if everyone %}
+        {% csrf_token %}
         <input id="id_everyone" name="everyone" type="hidden" value="Everyone" />
       {% endif %}
       <div class="panel-group">


### PR DESCRIPTION
Refactoring for the filter for exclude meant that the email form was rendered in slightly different way.
This resulted in not having the token that authenticates the user in the form.

It didn't get caught by tests because I never set the tests to look for this... it would a big enough job to test for this, that I'm skipping it.

1 line fix fixed it.