### PR TITLE
Sort by conference, then max price, then min price

### DIFF
--- a/ticketing/models.py
+++ b/ticketing/models.py
@@ -1,10 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
 from gbetext import role_options
-from django.db.models import (
-    Max,
-    Min,
-)
 from datetime import datetime
 
 
@@ -80,20 +76,6 @@ class BrownPaperEvents(models.Model):
             bpt_event=self,
             live=True,
             has_coupon=False).count()
-
-    @property
-    def min_price(self):
-        return TicketItem.objects.filter(
-            bpt_event=self,
-            live=True,
-            has_coupon=False).aggregate(Min('cost'))['cost__min']
-
-    @property
-    def max_price(self):
-        return TicketItem.objects.filter(
-            bpt_event=self,
-            live=True,
-            has_coupon=False).aggregate(Max('cost'))['cost__max']
 
     class Meta:
         verbose_name_plural = 'Brown Paper Events'


### PR DESCRIPTION
Eliminated 2 model properties in the process.
Also, I believe this will be more efficient in processing 1 DB query, instead of 1 query + O(2n) queries to process max/min prices on a per event basis.

The prices are (still) calculated only in terms of tickets that are "live" and not "has_coupon" - so if there are special offers of any sort, or comps, they don't factor into any of this. 

Fun fact - we DO have tickets currently with the same max price, but different min prices (see bordello vs rhinestone review) so this case totally happens. 

Very proud of myself with this one - the query to sort this out wasn't easy.  Good example of how far you can drive with the Django ORM.  