### PR TITLE
Gbe 196:  Fix for event edit erases performers

### DIFF
--- a/gbe/scheduling/views/edit_event_view.py
+++ b/gbe/scheduling/views/edit_event_view.py
@@ -161,6 +161,7 @@ class EditEventView(ManageVolWizardView):
             self.success_url,
             "volunteer_open",
             self.occurrence.pk,
+            event_settings[self.item.type.lower()]['roles'],
             self.is_formset_valid(worker_formset),
             worker_formset)
         context['worker_formset'] = worker_formset

--- a/gbe/scheduling/views/functions.py
+++ b/gbe/scheduling/views/functions.py
@@ -268,7 +268,10 @@ def setup_event_management_form(
     return (context, initial_form_info)
 
 
-def update_event(scheduling_form, occurrence_id, roles=None, people_formset=[]):
+def update_event(scheduling_form,
+                 occurrence_id,
+                 roles=None,
+                 people_formset=[]):
     start_time = get_start_time(scheduling_form.cleaned_data)
     people = []
     for assignment in people_formset:

--- a/gbe/scheduling/views/functions.py
+++ b/gbe/scheduling/views/functions.py
@@ -268,7 +268,7 @@ def setup_event_management_form(
     return (context, initial_form_info)
 
 
-def update_event(scheduling_form, occurrence_id, people_formset=[]):
+def update_event(scheduling_form, occurrence_id, roles=None, people_formset=[]):
     start_time = get_start_time(scheduling_form.cleaned_data)
     people = []
     for assignment in people_formset:
@@ -278,11 +278,14 @@ def update_event(scheduling_form, occurrence_id, people_formset=[]):
                     'worker'].workeritem.as_subtype.user_object,
                 public_id=assignment.cleaned_data['worker'].workeritem.pk,
                 role=assignment.cleaned_data['role'])]
+    if len(people) == 0:
+        people = None
     response = update_occurrence(
         occurrence_id,
         start_time,
         scheduling_form.cleaned_data['max_volunteer'],
         people=people,
+        roles=roles,
         locations=[scheduling_form.cleaned_data['location']],
         approval=scheduling_form.cleaned_data['approval'])
     return response
@@ -294,6 +297,7 @@ def process_post_response(request,
                           start_success_url,
                           next_step,
                           occurrence_id,
+                          roles=None,
                           additional_validity=True,
                           people_forms=[]):
     success_url = start_success_url
@@ -316,6 +320,7 @@ def process_post_response(request,
         new_event.save()
         response = update_event(context['scheduling_form'],
                                 occurrence_id,
+                                roles,
                                 people_forms)
         if request.POST.get('edit_event', 0) != "Save and Continue":
             success_url = "%s?%s-day=%d&filter=Filter&new=%s" % (

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -286,7 +286,7 @@ th.rotate-review {
 th.rotate div {
   transform: 
     /* Magic Numbers */
-    translate(0px, 51px)
+    translate(0px, 113px)
     /* 45 is really 360 - 45 */
     rotate(270deg);
   width: 20px;


### PR DESCRIPTION
Added a switch into the update_occurrence related function.
Found an additional snarl in the edit_volunteer threads.  Now edit event threads will put in the list of roles they intend to change, so that only those roles are cleared and set with new values.

Also slipped in the fix to act review display - rotated headers now line up right.