### PR TITLE
add bootstrap icons

### DIFF
--- a/ticketing/admin.py
+++ b/ticketing/admin.py
@@ -112,7 +112,9 @@ class TicketingEventsAdmin(admin.ModelAdmin):
             'description': '''What is shown on the 'I Want to Buy Tickets'
                 page.  Description is not shown there, it's pulled from
                 ticket source but not shown.  Display Icon must come from
-                https://simplelineicons.github.io/ -- NOTE:  Avoid the "."''',
+                https://simplelineicons.github.io/ or
+                https://icons.getbootstrap.com/ -- NOTE:  Use only the
+                classes, the i tag is already in the code.''',
         }),
     )
 

--- a/ticketing/templates/ticketing/purchase_tickets.tmpl
+++ b/ticketing/templates/ticketing/purchase_tickets.tmpl
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load static cms_tags %}
 {% block head %}
-      {% include "gray_grids_css.tmpl" %}
+  {% include "gray_grids_css.tmpl" %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
 {% endblock head %}
 
 {% block title %}


### PR DESCRIPTION
Per #233  - @burlexpo  and I agreed on a new icon library.
To keep compatible with what's live, I added it, I did not remove the old one - so both are available.