### PR TITLE
Gbe 268: Streamline class approval to scheduling

### DIFF
--- a/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -1,18 +1,4 @@
-{% extends 'gbe/gbe_table.tmpl' %}
-{% block title %}
-   Review Bids
-{% endblock %}
-{% block before_table %}
-  <h2 class="gbe-title">Act Bid Information for {{conference}}</h2>
-  <br/>
-      {% include "conference_picker.tmpl" %}
-  <br/>
-  <div>Red background indicates a user that has become inactive.</div>
-  <div>Blue background indicates bids that are awaitng your review.
-  Search for "Needs Review" to find them easily.</div>
-
-  <br/>
-{% endblock %}
+{% extends 'gbe/bid_review_list.tmpl' %}
 {% block tbody %}
   {% for row in rows %}
     <tr class="gbe-table-row {{ row.status }}">

--- a/gbe/templates/gbe/bid_review_frame.tmpl
+++ b/gbe/templates/gbe/bid_review_frame.tmpl
@@ -52,6 +52,9 @@
           {{ actionform.as_table }}
         </table>
         <br><br>
+        {% if extra_button %}
+        <input type="submit" name="extra_button" value="{{extra_button}}" class="gbe-btn-primary">&nbsp;
+        {% endif %}
         <input type="submit" value="Submit Form" class="gbe-btn-primary"><br><br>
         </form>
     </div>

--- a/gbe/templates/gbe/bid_review_list.tmpl
+++ b/gbe/templates/gbe/bid_review_list.tmpl
@@ -8,7 +8,7 @@
       {% include "conference_picker.tmpl" %}
   <br/>
   <div>Red background indicates a user that has become inactive.</div>
-  <div>Blue background indicates bids that are awaitng your review.
+  <div>Blue background indicates bids that are awaiting your review.
   Search for "Needs Review" to find them easily.</div>
 {% endblock %}
 {% block tbody %}
@@ -25,7 +25,7 @@
           {% endfor %}
           </td>
         {% endif %}
-          <td><a href="{{ row.review_url }}" class="gbe-table-link">
+          <td><a href="{{ row.review_url }}" role="button" class="btn gbe-btn-table btn-sm">
 	          Review</a></td>
       </tr>
     {% endfor %}

--- a/gbe/templates/gbe/class_review_list.tmpl
+++ b/gbe/templates/gbe/class_review_list.tmpl
@@ -1,0 +1,28 @@
+{% extends 'gbe/bid_review_list.tmpl' %}
+{% block tbody %}
+    {% for row in rows %}
+      <tr class="gbe-table-row {{ row.status }}">
+        {% for value in row.bid %}
+	        <td>{{ value|linebreaks }}</td>{% endfor %}
+        {% if "Reviews" in columns %}
+          <td>{% for review in row.reviews %}
+          {% if not forloop.first %}<hr/>{% endif %}
+          <b>Reviewer:</b> {{ review.evaluator.display_name }}<br>
+          <b>Recommendation:</b> {{ review.get_vote_display }}<br>
+          <b>Comment:</b> {{ review.notes }}<br>
+          {% endfor %}
+          </td>
+        {% endif %}
+          <td>
+            <a href="{{ row.review_url }}" role="button" class="btn gbe-btn-table btn-sm">
+	          Review</a>
+            {% if row.extra_button %}
+            <br><form action="{{ row.extra_button.url }}" method="post">
+                {% csrf_token %}
+                <input type="hidden" id="id_accepted" name="accepted" value="3">
+                <input type="hidden" name="extra_button" value="Schedule >>">
+                <button title="{{row.extra_button.text}}" type="submit" class="btn gbe-btn-table btn-sm">{{row.extra_button.text}}</button></form>
+            {% endif %}</td>
+      </tr>
+    {% endfor %}
+{% endblock %}

--- a/gbe/views/class_changestate_view.py
+++ b/gbe/views/class_changestate_view.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from gbe_logging import log_func
 from gbe.views import BidChangeStateView
 from gbe.models import Class
@@ -19,5 +20,11 @@ class ClassChangeStateView(BidChangeStateView):
             # editing are quite different
             self.object.e_title = self.object.b_title
             self.object.e_description = self.object.b_description
-        return super(ClassChangeStateView, self).bid_state_change(
-            request)
+            if int(request.POST['accepted']) == 3 and (
+                    'extra_button' in request.POST.keys()):
+                self.next_page = "%s?accepted_class=%d" % (
+                    reverse("create_class_wizard",
+                            urlconf='gbe.scheduling.urls',
+                            args=[self.object.b_conference.conference_slug]),
+                    self.object.eventitem_id)
+        return super(ClassChangeStateView, self).bid_state_change(request)

--- a/gbe/views/review_act_list_view.py
+++ b/gbe/views/review_act_list_view.py
@@ -60,6 +60,5 @@ class ReviewActListView(ReviewBidListView):
                     total_average/valid_categories, 2)
             else:
                 bid_row['total_average'] = "--"
-            self.row_hook(bid, bid_row)
             rows.append(bid_row)
         return rows

--- a/gbe/views/review_bid_list_view.py
+++ b/gbe/views/review_bid_list_view.py
@@ -35,10 +35,6 @@ class ReviewBidListView(View):
             bid__in=bids).select_related(
                 'evaluator').order_by('bid', 'evaluator')
 
-    def row_hook(self, bid, row):
-        # override on subclass
-        pass
-
     def set_row_basics(self, bid, review_query):
         bid_row = {
             'bid': bid.bid_review_summary,
@@ -68,7 +64,6 @@ class ReviewBidListView(View):
                 bid=bid.id).select_related(
                     'evaluator').order_by(
                         'evaluator')
-            self.row_hook(bid, bid_row)
             rows.append(bid_row)
         return rows
 

--- a/gbe/views/review_bid_list_view.py
+++ b/gbe/views/review_bid_list_view.py
@@ -72,9 +72,13 @@ class ReviewBidListView(View):
         review_query = self.review_query(bids)
         self.rows = self.get_rows(bids, review_query)
 
+    def groundwork(self, request):
+        pass
+
     @never_cache
     def get(self, request, *args, **kwargs):
         self.reviewer = validate_perms(request, self.reviewer_permissions)
+        self.groundwork(request)
         self.user = request.user
         if request.GET.get('conf_slug'):
             self.conference = Conference.by_slug(request.GET['conf_slug'])
@@ -92,6 +96,6 @@ class ReviewBidListView(View):
             return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
 
         self.conference_slugs = Conference.all_slugs()
-
-        return render(request, self.template,
+        return render(request,
+                      self.template,
                       self.get_context_dict())

--- a/gbe/views/review_class_list_view.py
+++ b/gbe/views/review_class_list_view.py
@@ -8,6 +8,27 @@ class ReviewClassListView(ReviewBidListView):
     object_type = Class
     bid_review_view_name = 'class_review'
     bid_review_list_view_name = 'class_review_list'
+    template = 'gbe/class_review_list.tmpl'
+
+    def set_row_basics(self, bid, review_query):
+        bid_row = super(ReviewClassListView, self).set_row_basics(bid,
+                                                                  review_query)
+        if bid.accepted == 3:
+            bid_row['extra_button'] = {
+                'url': reverse("class_changestate",
+                               urlconf='gbe.urls',
+                               args=[bid.id]),
+                'text': "Add to Schedule",
+            }
+        elif bid.ready_for_review:
+            bid_row['extra_button'] = {
+                'url': reverse("class_changestate",
+                               urlconf='gbe.urls',
+                               args=[bid.id]),
+                'text': "Accept & Schedule",
+            }
+        return bid_row
+
 
     def get_context_dict(self):
         return {'columns': self.object_type().bid_review_header,

--- a/gbe/views/review_class_view.py
+++ b/gbe/views/review_class_view.py
@@ -30,4 +30,5 @@ class ReviewClassView(ReviewBidView):
         context['scheduling_info'] = get_scheduling_info(self.object)
         context['performer'] = self.performer
         context['display_contact_info'] = True
+        context['extra_button'] = "Schedule >>"
         return context

--- a/gbe/views/review_class_view.py
+++ b/gbe/views/review_class_view.py
@@ -1,3 +1,4 @@
+from gbe.functions import validate_perms
 from gbe.forms import (
     PersonaForm,
     ClassBidForm,
@@ -23,6 +24,9 @@ class ReviewClassView(ReviewBidView):
         super(ReviewClassView, self).groundwork(request, args, kwargs)
         self.readonlyform_pieces = None
         self.performer = self.object.teacher
+        self.can_schedule = validate_perms(request,
+                                           ('Scheduling Mavens',),
+                                           False)
 
     def make_context(self):
         context = super(ReviewClassView, self).make_context()
@@ -30,5 +34,6 @@ class ReviewClassView(ReviewBidView):
         context['scheduling_info'] = get_scheduling_info(self.object)
         context['performer'] = self.performer
         context['display_contact_info'] = True
-        context['extra_button'] = "Schedule >>"
+        if self.can_schedule:
+            context['extra_button'] = "Schedule >>"
         return context

--- a/tests/gbe/scheduling/test_class_wizard.py
+++ b/tests/gbe/scheduling/test_class_wizard.py
@@ -108,7 +108,7 @@ class TestClassWizard(TestScheduling):
             response,
             ('<input type="radio" name="accepted_class" value="%d" ' +
              'id="id_accepted_class_1" checked />') % self.test_class.pk,
-            html=True)        
+            html=True)
         self.assertContains(
             response,
             'value="%s"' %

--- a/tests/gbe/scheduling/test_class_wizard.py
+++ b/tests/gbe/scheduling/test_class_wizard.py
@@ -98,6 +98,37 @@ class TestClassWizard(TestScheduling):
         self.assertNotContains(response, str(other_class.b_title))
         self.assertNotContains(response, str(other_class.teacher))
 
+    def test_authorized_user_third_form_get(self):
+        # this is how the class coordinator can fast schedule from review
+        login_as(self.privileged_user, self)
+        response = self.client.get("%s?accepted_class=%d" % (
+            self.url,
+            self.test_class.eventitem_id))
+        self.assertContains(
+            response,
+            ('<input type="radio" name="accepted_class" value="%d" ' +
+             'id="id_accepted_class_1" checked />') % self.test_class.pk,
+            html=True)        
+        self.assertContains(
+            response,
+            'value="%s"' %
+            self.test_class.b_title)
+        self.assertContains(
+            response,
+            'type="number" name="duration" value="1.0"')
+        self.assertContains(
+            response,
+            '<option value="%d">%s</option>' % (
+                self.day.pk,
+                self.day.day.strftime(GBE_DATE_FORMAT)),
+            html=True)
+        self.assertContains(
+            response,
+            '<option value="%d" selected>%s</option>' % (
+                self.test_class.teacher.pk,
+                str(self.test_class.teacher)),
+            html=True)
+
     def test_auth_user_can_pick_class(self):
         login_as(self.privileged_user, self)
         data = self.get_data()

--- a/tests/gbe/test_review_class.py
+++ b/tests/gbe/test_review_class.py
@@ -48,6 +48,20 @@ class TestReviewClass(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Bid Information')
+        self.assertContains(response, "Review Bids")
+        self.assertContains(response, "Bid Control for Coordinator")
+        self.assertNotContains(response, 'name="extra_button"')
+
+    def test_review_class_w_scheduling(self):
+        grant_privilege(self.privileged_user, 'Scheduling Mavens')
+        klass = ClassFactory()
+        url = reverse(self.view_name,
+                      args=[klass.pk],
+                      urlconf='gbe.urls')
+
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        self.assertContains(response, 'name="extra_button"')
 
     def test_review_class_post_form_invalid(self):
         klass = ClassFactory()

--- a/tests/gbe/test_review_class_list.py
+++ b/tests/gbe/test_review_class_list.py
@@ -1,5 +1,4 @@
 import gbe.models as conf
-import nose.tools as nt
 from django.test import (
     TestCase,
     Client,
@@ -44,8 +43,36 @@ class TestReviewClassList(TestCase):
             url,
             data={'conf_slug': self.conference.conference_slug})
 
-        nt.assert_equal(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Bid Information')
+        self.assertNotContains(response, "Accept &amp; Schedule")
+
+    def test_review_class_w_scheduling(self):
+        grant_privilege(self.privileged_user, 'Scheduling Mavens')
+        url = reverse(self.view_name, urlconf="gbe.urls")
+        login_as(self.privileged_user, self)
+        response = self.client.get(
+            url,
+            data={'conf_slug': self.conference.conference_slug})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Bid Information')
+        self.assertContains(response, "Accept &amp; Schedule")
+
+    def test_review_accepted_class_w_scheduling(self):
+        ClassFactory(
+            accepted=3,
+            b_conference=self.conference,
+            e_conference=self.conference,
+            submitted=True)
+        grant_privilege(self.privileged_user, 'Scheduling Mavens')
+        url = reverse(self.view_name, urlconf="gbe.urls")
+        login_as(self.privileged_user, self)
+        response = self.client.get(
+            url,
+            data={'conf_slug': self.conference.conference_slug})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Bid Information')
+        self.assertContains(response, "Add to Schedule")
 
     def test_review_class_bad_user(self):
         url = reverse(self.view_name, urlconf="gbe.urls")
@@ -53,7 +80,7 @@ class TestReviewClassList(TestCase):
         response = self.client.get(
             url,
             data={'conf_slug': self.conference.conference_slug})
-        nt.assert_equal(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_review_class_no_profile(self):
         url = reverse(self.view_name, urlconf="gbe.urls")
@@ -61,7 +88,7 @@ class TestReviewClassList(TestCase):
         response = self.client.get(
             url,
             data={'conf_slug': self.conference.conference_slug})
-        nt.assert_equal(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
     def test_review_class_inactive_user(self):
         ClassFactory(


### PR DESCRIPTION
Make it easier for the class coordinator to book a class in two ways:
1 - on the review/approve of an individual class page, there's an extra button - "Schedule >>" that goes direct to scheduling if the class is approved.  That saves a bunch of button clicks, and makes this a bit more workflow ish
2 - on the review class list page - there's an "Add to Schedule" or "Accept & Schedule" button for Approved or Needs Review classes respectively, that do as they say - making the class be approved (if it isn't already) and then putting the user on the scheduling page.

There's two downsides to these features:
- the scheduling puts the user on the schedule management page, it doesn't take them back to review (that was just too gnarly of a traversal).
- The "Add to Schedule" will keep adding classes, there's no display or awarness of whether or not the class is already scheduled.

Post-expo, it could be worth designing a conference dashboard, in the same spirit as the Show Dashboard, a user-centered display that does it all.  But this was a quick flow improvement that should make Expo Runtime chaos a bit easier.
