### PR TITLE
Show staffing report link correctly on event management

### DIFF
--- a/gbe/scheduling/views/edit_event_view.py
+++ b/gbe/scheduling/views/edit_event_view.py
@@ -124,7 +124,6 @@ class EditEventView(ManageVolWizardView):
                 self.manage_vol_url,
                 self.conference,
                 request,
-                [self.item.eventitem_id],
                 errorcontext=errorcontext,
                 occurrence_id=self.occurrence.pk))
         else:

--- a/gbe/scheduling/views/edit_staff_area_view.py
+++ b/gbe/scheduling/views/edit_staff_area_view.py
@@ -56,7 +56,7 @@ class EditStaffAreaView(ManageVolWizardView):
                 self.manage_vol_url,
                 self.conference,
                 request,
-                [self.staff_area.pk],
+                staff_area_id=self.staff_area.pk,
                 errorcontext=errorcontext,
                 labels=[self.conference.conference_slug,
                         self.staff_area.slug]))

--- a/gbe/scheduling/views/manage_vol_wizard_view.py
+++ b/gbe/scheduling/views/manage_vol_wizard_view.py
@@ -85,7 +85,7 @@ class ManageVolWizardView(View):
                                      manage_vol_info,
                                      conference,
                                      request,
-                                     report_data,
+                                     staff_area_id=None,
                                      errorcontext=None,
                                      occurrence_id=None,
                                      labels=[]):
@@ -145,10 +145,10 @@ class ManageVolWizardView(View):
             except:
                 pass
         context['actionform'] = actionform
-        if len(actionform) > 0:
+        if staff_area_id is not None:
             context['report_url'] = reverse('staff_area',
                                             urlconf='gbe.reporting.urls',
-                                            args=report_data)
+                                            args=[staff_area_id])
 
         if errorcontext and 'createform' in errorcontext:
             createform = errorcontext['createform']


### PR DESCRIPTION
Our staffing report got refactored and I didn't get the event management pages set properly.  So when I was demoing, I got some 404 errors.

This is the fix.  It needs context to figure it out, so take your time ... future me.