### PR TITLE
Gbe 287: make labels always visible 

### DIFF
--- a/gbe/templates/gbe/update_profile.tmpl
+++ b/gbe/templates/gbe/update_profile.tmpl
@@ -19,7 +19,7 @@
 <div class="row">
 <div class="col-md-6">
   {% for form in left_forms %}
-    {% include "form_table.tmpl" %}
+    {% include "form_table.tmpl" with two_col=True %}
   {% endfor %}
 </div>
 <div class="col-md-6">
@@ -40,7 +40,7 @@
 </div>
 <br>
   {% for form in right_forms %}
-  {% include "form_table.tmpl" %}
+    {% include "form_table.tmpl" with two_col=True %}
   {% endfor %}
 </div>
 </div>

--- a/gbe/templates/gbe/update_profile.tmpl
+++ b/gbe/templates/gbe/update_profile.tmpl
@@ -19,7 +19,7 @@
 <div class="row">
 <div class="col-md-6">
   {% for form in left_forms %}
-    {% include "form_table.tmpl" with two_col=True %}
+    {% include "form_table.tmpl" %}
   {% endfor %}
 </div>
 <div class="col-md-6">
@@ -40,7 +40,7 @@
 </div>
 <br>
   {% for form in right_forms %}
-  {% include "form_table.tmpl" with two_col=True %}
+  {% include "form_table.tmpl" %}
   {% endfor %}
 </div>
 </div>

--- a/gbe/views/make_bid_view.py
+++ b/gbe/views/make_bid_view.py
@@ -55,6 +55,18 @@ class MakeBidView(View):
                 reverse('profile_update', urlconf='gbe.urls'),
                 reverse('%s_create' % self.bid_type.lower(),
                         urlconf='gbe.urls'))
+        self.page_title = UserMessage.objects.get_or_create(
+                view=self.__class__.__name__,
+                code="PAGE_TITLE",
+                defaults={
+                    'summary': "%s Page Title" % self.bid_type,
+                    'description': self.page_title})[0].description
+        self.view_title = UserMessage.objects.get_or_create(
+                view=self.__class__.__name__,
+                code="FIRST_HEADER",
+                defaults={
+                    'summary': "%s First Header" % self.bid_type,
+                    'description': self.view_title})[0].description
 
         self.bid_object = None
         if "bid_id" in kwargs:

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -2,6 +2,7 @@
 body {margin: 0px;border: 0px;padding: 0px; font-size: 14px;font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;}
 .gbe-draft, .gbe-inactive {font-weight: bold;}
 .gbe-form-required {font-weight: bold;}
+.gbe-help-text {font-style: italic;}
 .gbe-title {
   font-family: 'Vast Shadow', cursive;
   letter-spacing: normal;

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -2,7 +2,6 @@
 body {margin: 0px;border: 0px;padding: 0px; font-size: 14px;font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;}
 .gbe-draft, .gbe-inactive {font-weight: bold;}
 .gbe-form-required {font-weight: bold;}
-.gbe-help-text {font-style: italic;}
 .gbe-title {
   font-family: 'Vast Shadow', cursive;
   letter-spacing: normal;
@@ -404,7 +403,7 @@ ul.long_choice
   column-count: 2;
 }
 
-td.form_field ul {padding: 5px 0px;}
+.form_field ul {padding: 5px 0px; margin-bottom: 1px;}
 td.form_field.long_choice ul li{width: 250px;height: 20px;}
 .form-group div div div ul li{list-style-type: none;}
 .gbe-choice-list ul li{list-style-type: none;font-size: larger;font-weight: bold;}

--- a/templates/form_table.tmpl
+++ b/templates/form_table.tmpl
@@ -18,42 +18,29 @@
 
     {# Include the visible fields #}
     {% for field in form.visible_fields %}
-    <div class="form-group">
+<div class="form-group">
 	<div class="container">
 	<div class="row">
-  {% if two_col %}<div class="col-md-5">
-  {% else %}<div class="col-md-4">{% endif %}
-	<label for="{{field.name}}" class="control-label">	      
-            {% if field.errors %}
-              <font class="gbe-form-error">!</font>&nbsp;&nbsp;
+  <div class="col-12"><b>
+      {% if field.errors %}
+        <font class="gbe-form-error">!</font>&nbsp;&nbsp;
 	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
-              <font class="gbe-form-required">*</font>
-            {% endif %} 
-            {% if field.errors %}
-                <font class="gbe-form-error">
-            {% endif %}
-            {% if field.name in draft_fields %}
-	        <font class="gbe-draft">{{ field.label_tag }}</font>
+        <font class="gbe-form-required">*</font>
+      {% endif %} 
+      {% if field.errors %}<font class="gbe-form-error">{% endif %}
+      {% if field.name in draft_fields %}
+	       <font class="gbe-draft">{{ field.label_tag }}</font>
 	    {% else %}
 	        {{ field.label_tag }}
 	    {% endif %}
-
-            {% if field.errors %}
-                </font>
-            {% endif %} 
-
-            {% if field.help_text %}
-                <span class="dropt" title="Help">
-                <img src= "{% static "img/question.png" %}" alt="?"/>
-                  <span style="width:200px;float:right;text-align:left;">
-                  {{ field.help_text }}
-                  </span>
-                </span>
-            {% endif %}
-	</label>
-	</div>
-  <div class="{% if two_col %}col-md-7{% else %}col-md-8{% endif %}"> 
-{{ field }}</div>
+      {% if field.errors %}
+        </font>
+      {% endif %}
+  </b></div>
+  {% if field.help_text %}
+  <div class="col-12"><span class="help-text">{{ field.help_text }}</span></div>
+  {% endif %}
+  <div class="col-12">{{ field }}</div>
 	</div>
 	</div>
         </div>

--- a/templates/form_table.tmpl
+++ b/templates/form_table.tmpl
@@ -17,11 +17,11 @@
   {{ form.non_field_errors }}</font>
 
     {# Include the visible fields #}
+<div class="container">
     {% for field in form.visible_fields %}
-<div class="form-group">
-	<div class="container">
-	<div class="row">
-  <div class="col-12">
+  <div class="form-group row">
+    {% if two_col %}<div class="col-md-5">
+    {% else %}<div class="col-md-4">{% endif %}
       {% if field.errors %}
         <font class="gbe-form-error">!</font>&nbsp;&nbsp;
 	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
@@ -36,25 +36,16 @@
       {% if field.errors %}
         </font>
       {% endif %}
-  </div>
-  <div class="col-12">{{ field }}</div>
-  {% if field.help_text %}
-  <div class="col-12"><span class="gbe-help-text">{{ field.help_text }}</span></div>
-  {% endif %}
-	</div>
-	</div>
-        </div>
-
-      {% if field.errors %}
-	<div class="container">
-        <div class="row">
-	  <div class="col-md-2">&nbsp;</div>
-	  <div class="col-md-4">
- 	    <label for="{{field.name}}">	      
-              <font class="gbe-form-error">{{ field.errors }}</font>
-            </label>
-	  </div>
-	</div>
-	</div>
+    </div>
+    <div class="{% if two_col %}col-md-7{% else %}col-md-8{% endif %} form_field">
+      {{ field }}
+      {% if field.help_text %}
+      <small class="form-text text-muted">{{ field.help_text }}</small>
       {% endif %}
+{% if field.errors %}
+      <font class="gbe-form-error">{{ field.errors }}</font>
+{% endif %}
+    </div>
+  </div>
     {% endfor %}
+</div>

--- a/templates/form_table.tmpl
+++ b/templates/form_table.tmpl
@@ -21,7 +21,7 @@
 <div class="form-group">
 	<div class="container">
 	<div class="row">
-  <div class="col-12"><b>
+  <div class="col-12">
       {% if field.errors %}
         <font class="gbe-form-error">!</font>&nbsp;&nbsp;
 	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
@@ -36,7 +36,7 @@
       {% if field.errors %}
         </font>
       {% endif %}
-  </b></div>
+  </div>
   {% if field.help_text %}
   <div class="col-12"><span class="help-text">{{ field.help_text }}</span></div>
   {% endif %}

--- a/templates/form_table.tmpl
+++ b/templates/form_table.tmpl
@@ -37,10 +37,10 @@
         </font>
       {% endif %}
   </div>
-  {% if field.help_text %}
-  <div class="col-12"><span class="help-text">{{ field.help_text }}</span></div>
-  {% endif %}
   <div class="col-12">{{ field }}</div>
+  {% if field.help_text %}
+  <div class="col-12"><span class="gbe-help-text">{{ field.help_text }}</span></div>
+  {% endif %}
 	</div>
 	</div>
         </div>

--- a/templates/form_table.tmpl
+++ b/templates/form_table.tmpl
@@ -20,8 +20,7 @@
 <div class="container">
     {% for field in form.visible_fields %}
   <div class="form-group row pb-2">
-    {% if two_col %}<div class="col-md-5">
-    {% else %}<div class="col-md-4">{% endif %}
+    <div class="{% if two_col %}col-md-5{% else %}col-md-4{% endif %}">
       {% if field.errors %}
         <font class="gbe-form-error">!</font>&nbsp;&nbsp;
 	    {% elif field.css_classes == 'required' or field.name in submit_fields %}

--- a/templates/form_table.tmpl
+++ b/templates/form_table.tmpl
@@ -19,7 +19,7 @@
     {# Include the visible fields #}
 <div class="container">
     {% for field in form.visible_fields %}
-  <div class="form-group row">
+  <div class="form-group row pb-2">
     {% if two_col %}<div class="col-md-5">
     {% else %}<div class="col-md-4">{% endif %}
       {% if field.errors %}
@@ -36,15 +36,15 @@
       {% if field.errors %}
         </font>
       {% endif %}
+      {% if field.help_text %}
+        <small class="form-text text-muted pb-1 mt-0">{{ field.help_text }}</small>
+      {% endif %}
     </div>
     <div class="{% if two_col %}col-md-7{% else %}col-md-8{% endif %} form_field">
       {{ field }}
-      {% if field.help_text %}
-      <small class="form-text text-muted">{{ field.help_text }}</small>
+      {% if field.errors %}
+        <font class="gbe-form-error">{{ field.errors }}</font>
       {% endif %}
-{% if field.errors %}
-      <font class="gbe-form-error">{{ field.errors }}</font>
-{% endif %}
     </div>
   </div>
     {% endfor %}


### PR DESCRIPTION
The main element of the #287 was:
- to make help text always visible as small, grey text that appears under the label.
Also tuned the padding & margins to visually separate the form fields in both mobile and desktop views (or anything in between).
- to make the the page title and view title on forms editable w/out code changes

The ticket is also an organization spot for other discussion which spawned more tickets.