### PR TITLE
Gbe 295:  simplify flow for bidding

### DIFF
--- a/gbe/forms/act_edit_form.py
+++ b/gbe/forms/act_edit_form.py
@@ -16,6 +16,7 @@ from gbe.models import Act
 from gbe_forms_text import (
     act_help_texts,
     act_bid_labels,
+    participant_form_help_texts,
 )
 from gbetext import (
     act_other_perf_options,
@@ -52,11 +53,14 @@ class ActEditDraftForm(ModelForm):
         label=act_bid_labels['description'],
         help_text=act_help_texts['description'],
         widget=Textarea)
+    phone = CharField(required=True,
+                      help_text=participant_form_help_texts['phone'])
 
     class Meta:
         model = Act
         fields = [
             'performer',
+            'phone',
             'shows_preferences',
             'b_title',
             'track_title',

--- a/gbe/forms/act_edit_form.py
+++ b/gbe/forms/act_edit_form.py
@@ -91,9 +91,6 @@ class ActEditDraftForm(ModelForm):
             if obj_data['shows_preferences']:
                 self.initial['shows_preferences'] = jsonify(
                     obj_data['shows_preferences'])
-            if obj_data['other_performance']:
-                self.initial['other_performance'] = jsonify(
-                    obj_data['other_performance'])
 
 
 class ActEditForm(ActEditDraftForm):

--- a/gbe/forms/class_bid_form.py
+++ b/gbe/forms/class_bid_form.py
@@ -15,6 +15,7 @@ from gbe_forms_text import (
     classbid_help_texts,
     classbid_labels,
     class_schedule_options,
+    participant_form_help_texts,
 )
 from gbe.functions import jsonify
 
@@ -38,11 +39,14 @@ class ClassBidDraftForm(ModelForm):
         required=True,
         widget=Textarea(attrs={'id': 'user-tiny-mce'}),
         label=classbid_labels['b_description'])
+    phone = CharField(required=True,
+                      help_text=participant_form_help_texts['phone'])
 
     class Meta:
         model = Class
         fields = ['b_title',
                   'teacher',
+                  'phone',
                   'b_description',
                   'maximum_enrollment',
                   'type',

--- a/gbe/forms/user_create_form.py
+++ b/gbe/forms/user_create_form.py
@@ -1,13 +1,11 @@
 from django.forms import (
     CharField,
     EmailField,
-    ModelForm,
 )
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 from gbe_forms_text import (
-    username_help,
-    username_label,
+    user_form_help,
 )
 from snowpenguin.django.recaptcha2.fields import ReCaptchaField
 from snowpenguin.django.recaptcha2.widgets import ReCaptchaWidget
@@ -21,10 +19,8 @@ from gbetext import (
 class UserCreateForm(UserCreationForm):
     required_css_class = 'required'
     error_css_class = 'error'
+    name = CharField(required=True, help_text=user_form_help['name'])
     email = EmailField(required=True)
-    username = CharField(label=username_label, help_text=username_help)
-    first_name = CharField(required=True)
-    last_name = CharField(required=True)
     verification = ReCaptchaField(widget=ReCaptchaWidget())
 
     def is_valid(self):
@@ -53,12 +49,17 @@ class UserCreateForm(UserCreationForm):
                 valid = False
         return valid
 
+    def save(self, commit=True):
+        form = super(UserCreateForm, self).save(commit=False)
+        form.username = form.email
+        if commit:
+            form.save()
+        return form
+
     class Meta:
         model = User
-        fields = ['username',
-                  'email',
-                  'first_name',
-                  'last_name',
+        fields = ['email',
+                  'name',
                   'password1',
                   'password2',
                   ]

--- a/gbe/models/profile.py
+++ b/gbe/models/profile.py
@@ -76,7 +76,7 @@ class Profile(WorkerItem):
 
     @property
     def complete(self):
-        return self.display_name and self.phone
+        return self.display_name
 
     def bids_to_review(self):
         from gbe.models import Biddable

--- a/gbe/views/make_act_view.py
+++ b/gbe/views/make_act_view.py
@@ -84,6 +84,7 @@ class MakeActView(MakeBidView):
                 'b_title': "%s Act - %s" % (
                     self.owner,
                     self.conference.conference_slug)}
+        initial['phone'] = self.owner.phone
         return initial
 
     def set_valid_form(self, request):

--- a/gbe/views/make_bid_view.py
+++ b/gbe/views/make_bid_view.py
@@ -265,6 +265,8 @@ class MakeBidView(View):
             self.bid_object = self.form.save(commit=False)
 
         self.set_valid_form(request)
+        if 'phone' in self.form.cleaned_data:
+            raise Exception("phone here")
 
         # if this isn't a draft, move forward through process, setting up
         # payment review if payment is needed

--- a/gbe/views/make_bid_view.py
+++ b/gbe/views/make_bid_view.py
@@ -266,7 +266,8 @@ class MakeBidView(View):
 
         self.set_valid_form(request)
         if 'phone' in self.form.cleaned_data:
-            raise Exception("phone here")
+            self.owner.phone = self.form.cleaned_data['phone']
+            self.owner.save()
 
         # if this isn't a draft, move forward through process, setting up
         # payment review if payment is needed

--- a/gbe/views/make_class_view.py
+++ b/gbe/views/make_class_view.py
@@ -54,6 +54,7 @@ class MakeClassView(MakeBidView):
         if not self.bid_object:
             initial = {'owner': self.owner,
                        'teacher': self.teachers[0]}
+        initial['phone'] = self.owner.phone
         return initial
 
     def set_up_form(self):

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -9,7 +9,6 @@ participant_labels = {
     'address1': ('Street Address'),
     'address2': ('Street Address (cont.)'),
     'best_time': ('Best time to call'),
-    'offsite_preferred': ('Offsite phone'),
     'how_heard': "How did you hear about The Expo?",
     'purchase_email': ('BPT Purchase Email'),
 }
@@ -261,21 +260,11 @@ participant_form_help_texts = {
     communications. This defaults to your First and Last Name.'),
     'phone': ('A phone number we can use to reach you when you are at the \
     Expo, such as cell phone.'),
-    'offsite_preferred': ('Your preferred phone number (if different from \
-    above), for communication before the Expo.  Use this if you prefer to \
-    get phone calls at a phone you cannot bring to the Expo.'),
     'legal_name': ('Please provide us with your legal first and last names.\
      This information is only used by the event staff never shared with anyone\
      without your prior permission.\
      Please use your stage name in the Badge Name field.'),
 }
-
-
-phone_validation_error_text = (
-    'If Preferred contact is a Phone call or '
-    'Text, we need your phone number as either an Onsite phone or Offsite '
-    'preferred.')
-
 
 troupe_header_text = '''More than 1 person, who will be performing on stage \
 together.'''
@@ -311,10 +300,6 @@ available_time_conflict = \
 
 unavailable_time_conflict = \
     'Unavailable times conflict with Available times.'
-
-phone_error1 = ['Phone number needed here']
-phone_error2 = ['... or here ']
-phone_error3 = ['...or choose a contact method that does not require a phone.']
 
 tech_labels = {
     'track_title': 'Name of Song',
@@ -385,9 +370,6 @@ starting_position_choices = [
     ('In the house', 'In the house')
 ]
 
-bidder_info_phone_error = ('A phone number we can use to reach you '
-                           ' when you are at the Expo, such as cell phone.')
-
 act_length_required = ("Act Length (mm:ss) is required.")
 act_length_too_long = ("The Act Length is too long.")
 
@@ -406,7 +388,8 @@ act_help_texts = {
                     'clean the stage after your act. Please do not leave '
                     'anything on the stage (water, glitter, confetti, etc.)'),
     'performer': ('Select the stage persona or troupe who will be performing.'
-                  ' Hit "create" to create a new persona or troupe.'),
+                  ' Hit "+" to create a new individual or troupe bio, or the '
+                  'pencil to edit the selected item.'),
     'other_performance': ("Don't feel badly if you're not accepted to perform "
                           "in one of the formal shows. We have a ton of other "
                           "ways to get your performance fix! Indicating that "

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -369,9 +369,6 @@ starting_position_choices = [
     ('In the house', 'In the house')
 ]
 
-act_length_required = ("Act Length (mm:ss) is required.")
-act_length_too_long = ("The Act Length is too long.")
-
 act_help_texts = {
     'shows_preferences': 'Check as many as apply to you',
     'act_duration': ('Length of entire act in mm:ss - please include any time '
@@ -434,18 +431,6 @@ act_bid_labels = {
     'video_link': 'URL of Video'
 }
 summer_bid_label = "I am available to perform on"
-
-bio_required = "Performer/Troupe history is required."
-bio_too_long = "The History is too long."
-bio_help_text = 'Please give a brief performer/troupe history.'
-
-act_description_required = "Description of the Act is required."
-act_description_too_long = "The Description  is too long."
-
-promo_required = "Please provide a photo."
-promo_help_text = ('Please_upload a photograph of yourself (photo must '
-                   'be under 10 MB).')
-
 persona_labels = {'name': ('Stage Name'),
                   'homepage': ('Web Site'),
                   'contact': ('Agent/Contact'),
@@ -481,8 +466,6 @@ persona_help_texts = {
                   'your performer page.'),
 }
 
-bid_review_options = ('Accepted', 'Declined', 'Waitlist')
-
 acceptance_labels = {
     'accepted': ('Change Bid State')
 }
@@ -501,22 +484,10 @@ actbid_error_messages = {
         'max_length': ("The title of the act is too long."),
     }}
 
-actbid_name_missing = ['...a name is needed']
 actbid_otherperformers_missing = ['...please describe the other performers.']
 actbid_group_wrong = ['If this is a group... other entries are needed.']
 actbid_group_error = '''The submission says this is a group act, but there are \
 no other performers listed'''
-
-video_error1 = ['Either say that no video is provided.']
-video_error2 = ['... or provide video']
-video_error3 = '''The Video Description suggests a Video Link would be provided, \
-but none was provided.'''
-
-description_required = ("Description is required.")
-description_too_long = ("The Description is too long.")
-description_help_text = '''For use on the The Great Burlesque Expo website, \
-    in advertising and in any schedule of events. The description should be \
-    1-2 paragraphs.'''
 
 avoided_constraints_popup_text = '''<strong>Info!</strong>
     We will do our best to accommodate everyone's requests when scheduling
@@ -601,7 +572,6 @@ class_schedule_options = [('0', 'Friday Afternoon'),
                           ('3', 'Sunday Morning'),
                           ('4', 'Sunday Afternoon')]
 
-space_error1 = ('''A class of workshop type cannot have space choices.''')
 space_type_error1 = ('''A workshop has seating in a ring around the room, \
     other options are not available.''')
 space_error2 = ('''A class of movement type cannot have lecture space \
@@ -630,10 +600,6 @@ panel_help_texts = {
                    'before, either at a convention, or elsewhere. If this '
                    'content has run before, please describe where and when.'),
 }
-
-vendor_description_help_text = ('Please describe your good or services in 250 '
-                                'words or less. We will publish this text on '
-                                'the website.')
 
 vendor_labels = {
     'description': 'Description of Goods or Services',
@@ -678,18 +644,6 @@ vendor_schedule_options = [('VSH0', 'Saturday, 9am to noon'),
                            ('VSH6', 'Sunday, 4pm to 8pm'),
                            ('VSH7', 'Sunday after 8pm')]
 vendor_featured_options = [('Featured', 'Featured')]
-
-help_time_choices = (('Saturday, 9am to noon', 'Saturday, 9am to noon'),
-                     ('Saturday, 12pm to 4pm', 'Saturday, 12p to 4pm'),
-                     ('Saturday, 4pm to 8pm', 'Saturday, 4pm to 8pm'),
-                     ('Saturday after 8pm', 'Saturday after 8pm'),
-                     ('Sunday, 9am to noon', 'Sunday, 9am to noon'),
-                     ('Sunday, 12pm to 4pm', 'Sunday, 12p to 4pm'),
-                     ('Sunday, 4pm to 8pm', 'Sunday, 4pm to 8pm'),
-                     ('Sunday after 8pm', 'Sunday after 8pm'))
-
-#  Would like to be able to insert this into the class proposal form
-#  from upstream
 
 class_proposal_form_text = {
     'header': ("Thanks for your interest in the Great Burlesque Expo. "

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -828,10 +828,10 @@ ticketing_event_help_text = {
 donation_labels = {'donation': 'Fee (pay what you will)'}
 donation_help_text = {'donation': '''Our fee is set to the minimum shown \
 here, but you may choose to pay more.'''}
-
-username_label = 'Login'
-username_help = ("Required. 30 characters or fewer. Letters, digits and "
-                 "@ . + - _ only.")
+user_form_help = {
+    'name': ('The name you would like to see on any badges, communication '
+        'from this event, or public ways of referring to you.')
+}
 
 conference_participation_types = [('Teacher', 'Teacher'),
                                   ('Moderator', 'Moderator'),

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -258,8 +258,7 @@ participant_form_help_texts = {
     This can be a stage name, or your real-world name, or anything that you \
     want to have printed on your Expo badge and other official Expo \
     communications. This defaults to your First and Last Name.'),
-    'phone': ('A phone number we can use to reach you when you are at the \
-    Expo, such as cell phone.'),
+    'phone': 'For the Expo only, in case we need to reach you.',
     'legal_name': ('Please provide us with your legal first and last names.\
      This information is only used by the event staff never shared with anyone\
      without your prior permission.\

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -813,7 +813,7 @@ donation_help_text = {'donation': '''Our fee is set to the minimum shown \
 here, but you may choose to pay more.'''}
 user_form_help = {
     'name': ('The name you would like to see on any badges, communication '
-        'from this event, or public ways of referring to you.')
+             'from this event, or public ways of referring to you.')
 }
 
 conference_participation_types = [('Teacher', 'Teacher'),

--- a/tests/contexts/purchase_ticket_context.py
+++ b/tests/contexts/purchase_ticket_context.py
@@ -13,8 +13,8 @@ class PurchasedTicketContext:
         self.conference = conference or ConferenceFactory()
         self.profile = profile or ProfileFactory(
             display_name="",
-            user_object__first_name="first",
-            user_object__last_name="last")
+            user_object__first_name="firstname",
+            user_object__last_name="lastname")
         self.transaction = TransactionFactory(
             ticket_item__ticketing_event__conference=self.conference,
             purchaser__matched_to_user=self.profile.user_object,

--- a/tests/contexts/purchase_ticket_context.py
+++ b/tests/contexts/purchase_ticket_context.py
@@ -11,7 +11,10 @@ class PurchasedTicketContext:
 
     def __init__(self, profile=None, conference=None):
         self.conference = conference or ConferenceFactory()
-        self.profile = profile or ProfileFactory()
+        self.profile = profile or ProfileFactory(
+            display_name="",
+            user_object__first_name="first",
+            user_object__last_name="last")
         self.transaction = TransactionFactory(
             ticket_item__ticketing_event__conference=self.conference,
             purchaser__matched_to_user=self.profile.user_object,

--- a/tests/factories/gbe_factories.py
+++ b/tests/factories/gbe_factories.py
@@ -53,6 +53,7 @@ class UserFactory(DjangoModelFactory):
     email = Sequence(lambda n: 'John_%s@smith.com' % str(n))
     username = LazyAttribute(lambda a: "%s" % (a.email))
 
+
 class ProfileFactory(DjangoModelFactory):
     class Meta:
         model = conf.Profile

--- a/tests/factories/gbe_factories.py
+++ b/tests/factories/gbe_factories.py
@@ -50,11 +50,8 @@ class WorkerItemFactory(DjangoModelFactory):
 class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
-    first_name = Sequence(lambda n: 'John_%s' % str(n))
-    last_name = 'Smith'
-    username = LazyAttribute(lambda a: "%s" % (a.first_name))
-    email = LazyAttribute(lambda a: '%s@smith.com' % (a.username))
-
+    email = Sequence(lambda n: 'John_%s@smith.com' % str(n))
+    username = LazyAttribute(lambda a: "%s" % (a.email))
 
 class ProfileFactory(DjangoModelFactory):
     class Meta:
@@ -64,9 +61,7 @@ class ProfileFactory(DjangoModelFactory):
     state = 'MD'
     zip_code = '12345'
     country = 'USA'
-    display_name = LazyAttribute(
-        lambda a: "%s_%s" % (a.user_object.first_name,
-                             a.user_object.last_name))
+    display_name = Sequence(lambda n: "%s_%s" % (str(n), str(n)))
 
 
 class ShowFactory(DjangoModelFactory):

--- a/tests/factories/gbe_factories.py
+++ b/tests/factories/gbe_factories.py
@@ -60,13 +60,10 @@ class ProfileFactory(DjangoModelFactory):
     class Meta:
         model = conf.Profile
     user_object = SubFactory(UserFactory)
-    address1 = '123 Main St.'
-    address2 = Sequence(lambda n: 'Apt. %d' % n)
     city = 'Smithville'
     state = 'MD'
     zip_code = '12345'
     country = 'USA'
-    phone = '617-282-9268'
     display_name = LazyAttribute(
         lambda a: "%s_%s" % (a.user_object.first_name,
                              a.user_object.last_name))

--- a/tests/gbe/test_create_act.py
+++ b/tests/gbe/test_create_act.py
@@ -24,6 +24,7 @@ from gbetext import (
 )
 from gbe.models import (
     Conference,
+    Profile,
     UserMessage,
 )
 from tests.functions.ticketing_functions import setup_fees
@@ -49,6 +50,7 @@ class TestCreateAct(TestCase):
     def get_act_form(self, submit=False, valid=True):
 
         form_dict = {'theact-shows_preferences': [4],
+                     'theact-phone': '111-222-3333',
                      'theact-b_title': 'An act',
                      'theact-track_title': 'a track',
                      'theact-track_artist': 'an artist',
@@ -255,6 +257,8 @@ class TestCreateAct(TestCase):
             view='MakeActView',
             code='DRAFT_SUCCESS')
         response, data = self.post_unpaid_act_draft()
+        profile = Profile.objects.get(pk=self.performer.performer_profile.pk)
+        self.assertEqual(profile.phone, '111-222-3333')
         self.assertEqual(200, response.status_code)
         assert_alert_exists(
             response, 'success', 'Success', msg.description)

--- a/tests/gbe/test_create_class.py
+++ b/tests/gbe/test_create_class.py
@@ -19,6 +19,7 @@ from gbetext import (
 from gbe_utils.text import no_profile_msg
 from gbe.models import (
     Conference,
+    Profile,
     UserMessage
 )
 
@@ -38,6 +39,7 @@ class TestCreateClass(TestCase):
                        submit=False,
                        invalid=False):
         data = {'theclass-teacher': self.performer.pk,
+                'theclass-phone': '111-222-3333',
                 'theclass-b_title': 'A class',
                 'theclass-b_description': 'a description',
                 'theclass-length_minutes': 60,
@@ -192,6 +194,8 @@ class TestCreateClass(TestCase):
         '''class_bid, not submitting and no other problems,
         should redirect to home'''
         response, data = self.post_bid(submit=False)
+        profile = Profile.objects.get(pk=self.performer.performer_profile.pk)
+        self.assertEqual(profile.phone, '111-222-3333')
         self.assertEqual(200, response.status_code)
         assert_alert_exists(
             response, 'success', 'Success', default_class_draft_msg)

--- a/tests/gbe/test_edit_class.py
+++ b/tests/gbe/test_edit_class.py
@@ -108,6 +108,8 @@ class TestEditClass(TestCase):
     def test_edit_bid_not_post(self):
         '''edit_bid, not post, should take us to edit process'''
         klass = ClassFactory()
+        klass.teacher.performer_profile.phone = "555-666-7777"
+        klass.teacher.performer_profile.save()
         url = reverse(self.view_name,
                       args=[klass.pk],
                       urlconf='gbe.urls')
@@ -115,6 +117,7 @@ class TestEditClass(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Submit a Class')
+        self.assertContains(response, "555-666-7777")
 
     def test_edit_bid_verify_info_popup_text(self):
         klass = ClassFactory()

--- a/tests/gbe/test_edit_class.py
+++ b/tests/gbe/test_edit_class.py
@@ -16,7 +16,8 @@ from gbetext import (
 )
 from gbe.models import (
     Conference,
-    UserMessage
+    Profile,
+    UserMessage,
 )
 
 
@@ -33,6 +34,7 @@ class TestEditClass(TestCase):
 
     def get_form(self, submit=True, invalid=False):
         data = {"theclass-teacher": self.teacher.pk,
+                'theclass-phone': '111-222-3333',
                 "theclass-b_title": 'A class',
                 "theclass-b_description": 'a description',
                 "theclass-length_minutes": 60,
@@ -47,24 +49,22 @@ class TestEditClass(TestCase):
         return data
 
     def post_class_edit_submit(self):
-        klass = ClassFactory()
+        klass = ClassFactory(teacher=self.teacher)
         url = reverse(self.view_name,
                       args=[klass.pk],
                       urlconf='gbe.urls')
         login_as(klass.teacher.performer_profile, self)
         data = self.get_form()
-        data['theclass-teacher'] = klass.teacher.pk
         response = self.client.post(url, data=data, follow=True)
         return response, data
 
     def post_class_edit_draft(self):
-        klass = ClassFactory()
+        klass = ClassFactory(teacher=self.teacher)
         url = reverse(self.view_name,
                       args=[klass.pk],
                       urlconf='gbe.urls')
         login_as(klass.teacher.performer_profile, self)
         data = self.get_form(submit=False)
-        data['theclass-teacher'] = klass.teacher.pk
         response = self.client.post(url, data=data, follow=True)
         return response, data
 
@@ -166,7 +166,8 @@ class TestEditClass(TestCase):
         response, data = self.post_class_edit_submit()
         self.assertEqual(response.status_code, 200)
         self.assertRedirects(response, reverse("home", urlconf='gbe.urls'))
-        # should test some change to class
+        profile = Profile.objects.get(pk=self.teacher.performer_profile.pk)
+        self.assertEqual(profile.phone, '111-222-3333')
 
     def test_class_submit_make_message(self):
         '''class_bid, not submitting and no other problems,

--- a/tests/gbe/test_login.py
+++ b/tests/gbe/test_login.py
@@ -15,7 +15,7 @@ class TestIndex(TestCase):
         self.url = reverse('home', urlconf='gbe.urls')
 
         # User/Human setup
-        self.profile = ProfileFactory()
+        self.profile = ProfileFactory(user_object__email="different")
 
     def test_login_w_email(self):
         '''Basic test of landing_page view

--- a/tests/gbe/test_make_bid.py
+++ b/tests/gbe/test_make_bid.py
@@ -78,6 +78,7 @@ class TestMakeBid(TestCase):
                       urlconf='gbe.urls')
         login_as(self.performer.performer_profile, self)
         data = {'theclass-teacher': self.performer.pk,
+                'theclass-phone': '111-222-3333',
                 'theclass-b_title': 'A class',
                 'theclass-b_description': 'a description',
                 'theclass-length_minutes': 60,

--- a/tests/gbe/test_make_summer_act.py
+++ b/tests/gbe/test_make_summer_act.py
@@ -39,6 +39,7 @@ class TestSummerAct(TestCase):
 
         form_dict = {'theact-shows_preferences': [4],
                      'theact-b_title': 'An act',
+                     'theact-phone': '111-222-3333',
                      'theact-track_title': 'a track',
                      'theact-track_artist': 'an artist',
                      'theact-b_description': 'a description',

--- a/tests/gbe/test_profile_autocomplete.py
+++ b/tests/gbe/test_profile_autocomplete.py
@@ -1,10 +1,7 @@
 from django.test import TestCase
 from django.test import Client
 from django.urls import reverse
-from tests.factories.gbe_factories import (
-    ProfileFactory,
-    UserFactory,
-)
+from tests.factories.gbe_factories import ProfileFactory
 from tests.functions.gbe_functions import (
     grant_privilege,
     login_as,
@@ -67,8 +64,7 @@ class TestProfileAutoComplete(TestCase):
 
     def test_list_profile_w_search_by_last_name(self):
         profile1 = ProfileFactory(user_object__last_name="profile1")
-        profile2 = ProfileFactory(user_object=UserFactory(
-            last_name="NOT HERE"))
+        profile2 = ProfileFactory(user_object__last_name="NOT HERE")
         login_as(self.user, self)
         response = self.client.get("%s?q=%s" % (
             self.url,

--- a/tests/gbe/test_profile_autocomplete.py
+++ b/tests/gbe/test_profile_autocomplete.py
@@ -55,8 +55,8 @@ class TestProfileAutoComplete(TestCase):
         self.assertNotContains(response, profile2.display_name)
 
     def test_list_profile_w_search_by_first_name(self):
-        profile1 = ProfileFactory()
-        profile2 = ProfileFactory()
+        profile1 = ProfileFactory(user_object__first_name="profile1")
+        profile2 = ProfileFactory(user_object__first_name="profile2")
         login_as(self.user, self)
         response = self.client.get("%s?q=%s" % (
             self.url,
@@ -66,7 +66,7 @@ class TestProfileAutoComplete(TestCase):
         self.assertNotContains(response, profile2.display_name)
 
     def test_list_profile_w_search_by_last_name(self):
-        profile1 = ProfileFactory()
+        profile1 = ProfileFactory(user_object__last_name="profile1")
         profile2 = ProfileFactory(user_object=UserFactory(
             last_name="NOT HERE"))
         login_as(self.user, self)

--- a/tests/ticketing/test_transactions.py
+++ b/tests/ticketing/test_transactions.py
@@ -295,7 +295,8 @@ class TestTransactions(TestCase):
             "%s - Vendor" % old_context.transaction.ticket_item.title)
         self.assertNotContains(response, "- Act")
         self.assertNotContains(response, context.transaction.purchaser.email)
-        self.assertNotContains(response, context.profile.display_name)
+        self.assertNotContains(response,
+                               context.profile.user_object.first_name)
         self.assertNotContains(response, context.transaction.ticket_item.title)
 
     def test_transactions_old_conf_limbo_purchase_user_view(self):
@@ -319,7 +320,8 @@ class TestTransactions(TestCase):
         self.assertNotContains(response, "- Vendor")
         self.assertNotContains(response, "- Act")
         self.assertNotContains(response, context.transaction.purchaser.email)
-        self.assertNotContains(response, context.profile.display_name)
+        self.assertNotContains(response,
+                               context.profile.user_object.first_name)
         self.assertNotContains(response, context.transaction.ticket_item.title)
 
     @patch('urllib.request.urlopen', autospec=True)


### PR DESCRIPTION
Described by #295 
Also did some test flow updates and removed some text strings that don't seem to be used anywhere (related to phone number).
The profile update flow still requires phone number - I need to put in some real logic there, so bidders can't remove a phone number, so that's handled under a separate ticket.

Worth noting that there's a rather sweeping change here - the phone is no longer required to make a profile "complete", we need that for the flows to work the way we want. 