### PR TITLE
GBE-292: make the icons into buttons with words for select and add/edit another widget

### DIFF
--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -384,8 +384,8 @@ act_help_texts = {
                     'clean the stage after your act. Please do not leave '
                     'anything on the stage (water, glitter, confetti, etc.)'),
     'performer': ('Select the stage persona or troupe who will be performing.'
-                  ' Hit "+" to create a new individual or troupe bio, or the '
-                  'pencil to edit the selected item.'),
+                  ' Click "Add" to create a new individual or troupe bio, or "Edit" '
+                  'change the selected item.'),
     'other_performance': ("Don't feel badly if you're not accepted to perform "
                           "in one of the formal shows. We have a ton of other "
                           "ways to get your performance fix! Indicating that "

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -384,8 +384,8 @@ act_help_texts = {
                     'clean the stage after your act. Please do not leave '
                     'anything on the stage (water, glitter, confetti, etc.)'),
     'performer': ('Select the stage persona or troupe who will be performing.'
-                  ' Click "Add" to create a new individual or troupe bio, or "Edit" '
-                  'change the selected item.'),
+                  ' Click "Add" to create a new individual or troupe bio, or'
+                  ' "Edit" change the selected item.'),
     'other_performance': ("Don't feel badly if you're not accepted to perform "
                           "in one of the formal shows. We have a ton of other "
                           "ways to get your performance fix! Indicating that "

--- a/templates/django_addanother/related_widget_wrapper.html
+++ b/templates/django_addanother/related_widget_wrapper.html
@@ -3,7 +3,7 @@
     {{ widget }}
 
     {% if edit_related_url %}
-    <a class="related-widget-wrapper-link change-related btn btn-secondary btn-sm" id="change_id_{{ name }}"
+    <a class="related-widget-wrapper-link change-related btn gbe-btn-secondary btn-sm" id="change_id_{{ name }}"
         href=""
         data-href-template="{{ edit_related_url }}?{{ url_params }}"
         title="{% blocktrans %}Edit related{% endblocktrans %}">
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if add_related_url %}
-    <a class="related-widget-wrapper-link add-related btn btn-secondary btn-sm" id="add_id_{{ name }}"
+    <a class="related-widget-wrapper-link add-related btn gbe-btn-secondary btn-sm" id="add_id_{{ name }}"
         href="{{ add_related_url }}?{{ url_params }}"
         title="{% blocktrans %}Add another{% endblocktrans %}">
         {% trans 'Add' %}

--- a/templates/django_addanother/related_widget_wrapper.html
+++ b/templates/django_addanother/related_widget_wrapper.html
@@ -3,7 +3,7 @@
     {{ widget }}
 
     {% if edit_related_url %}
-    <a class="related-widget-wrapper-link change-related btn gbe-btn-secondary btn-sm" id="change_id_{{ name }}"
+    <a class="related-widget-wrapper-link change-related btn btn-secondary btn-sm" id="change_id_{{ name }}"
         href=""
         data-href-template="{{ edit_related_url }}?{{ url_params }}"
         title="{% blocktrans %}Edit related{% endblocktrans %}">
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if add_related_url %}
-    <a class="related-widget-wrapper-link add-related btn gbe-btn-secondary btn-sm" id="add_id_{{ name }}"
+    <a class="related-widget-wrapper-link add-related btn btn-secondary btn-sm" id="add_id_{{ name }}"
         href="{{ add_related_url }}?{{ url_params }}"
         title="{% blocktrans %}Add another{% endblocktrans %}">
         {% trans 'Add' %}

--- a/templates/django_addanother/related_widget_wrapper.html
+++ b/templates/django_addanother/related_widget_wrapper.html
@@ -1,0 +1,21 @@
+{% load i18n static %}
+<div class="related-widget-wrapper">
+    {{ widget }}
+
+    {% if edit_related_url %}
+    <a class="related-widget-wrapper-link change-related btn btn-secondary btn-sm" id="change_id_{{ name }}"
+        href=""
+        data-href-template="{{ edit_related_url }}?{{ url_params }}"
+        title="{% blocktrans %}Edit related{% endblocktrans %}">
+        {% trans 'Edit' %}
+    </a>
+    {% endif %}
+
+    {% if add_related_url %}
+    <a class="related-widget-wrapper-link add-related btn btn-secondary btn-sm" id="add_id_{{ name }}"
+        href="{{ add_related_url }}?{{ url_params }}"
+        title="{% blocktrans %}Add another{% endblocktrans %}">
+        {% trans 'Add' %}
+    </a>
+    {% endif %}
+</div>


### PR DESCRIPTION
#292 
The trick is to override the template that the django-addanotherwidget uses.  Once I figured out where to put it, it was easy.
Using bootstrap (as ever) to style the button.