### PR TITLE
GBE-313:  Rehearsals don't have a calendar type label

### DIFF
--- a/gbe/scheduling/views/copy_collections_view.py
+++ b/gbe/scheduling/views/copy_collections_view.py
@@ -129,8 +129,10 @@ class CopyCollectionsView(View):
 
             for sub_event_id in form.cleaned_data["copied_event"]:
                 response = get_occurrence(sub_event_id)
-                labels = [conference.conference_slug,
-                          response.occurrence.as_subtype.calendar_type]
+                labels = [conference.conference_slug]
+                if response.occurrence.as_subtype.calendar_type:
+                    labels += [response.occurrence.as_subtype.calendar_type]
+
                 response = self.copy_event(
                     response.occurrence,
                     delta,

--- a/tests/gbe/scheduling/test_copy_occurrence_view.py
+++ b/tests/gbe/scheduling/test_copy_occurrence_view.py
@@ -729,7 +729,7 @@ class TestCopyOccurrence(TestGBE):
             'success',
             'Success',
             'Occurrence has been updated.<br>%s, Start Time: %s' % (
-                show_context.event.e_title,
+                show_context.show.e_title,
                 datetime.combine(
                     another_day.day,
                     show_context.sched_event.starttime.time()).strftime(

--- a/tests/gbe/scheduling/test_copy_occurrence_view.py
+++ b/tests/gbe/scheduling/test_copy_occurrence_view.py
@@ -685,6 +685,57 @@ class TestCopyOccurrence(TestGBE):
                     GBE_DATETIME_FORMAT)))
         self.assertNotContains(response, "approval_needed")
 
+    def test_copy_rehearsal(self):
+        another_day = ConferenceDayFactory()
+        show_context = ShowContext()
+        rehearsal, slot = show_context.make_rehearsal()
+        url = reverse(
+            self.view_name,
+            args=[show_context.sched_event.pk],
+            urlconf='gbe.scheduling.urls')
+        data = {
+            'copy_mode': 'include_parent',
+            'copy_to_day': another_day.pk,
+            'copied_event': slot.pk,
+            'room': self.context.room.pk,
+            'pick_event': "Finish",
+        }
+        login_as(self.privileged_user, self)
+        max_pk = Event.objects.latest('pk').pk
+        response = self.client.post(url, data=data, follow=True)
+        new_occurrences = []
+        for occurrence in Event.objects.filter(pk__gt=max_pk).order_by('pk'):
+            new_occurrences += [occurrence.pk]
+        redirect_url = "%s?%s-day=%d&filter=Filter&new=%s" % (
+            reverse('manage_event_list',
+                    urlconf='gbe.scheduling.urls',
+                    args=[another_day.conference.conference_slug]),
+            another_day.conference.conference_slug,
+            another_day.pk,
+            str(new_occurrences).replace(" ", "%20"))
+        self.assertRedirects(response, redirect_url)
+        assert_alert_exists(
+            response,
+            'success',
+            'Success',
+            'Occurrence has been updated.<br>%s, Start Time: %s' % (
+                rehearsal.e_title,
+                datetime.combine(
+                    another_day.day,
+                    slot.starttime.time()).strftime(
+                    GBE_DATETIME_FORMAT)))
+        assert_alert_exists(
+            response,
+            'success',
+            'Success',
+            'Occurrence has been updated.<br>%s, Start Time: %s' % (
+                show_context.event.e_title,
+                datetime.combine(
+                    another_day.day,
+                    show_context.sched_event.starttime.time()).strftime(
+                    GBE_DATETIME_FORMAT)))
+        self.assertNotContains(response, "approval_needed")
+
     def test_copy_child_not_like_parent(self):
         another_day = ConferenceDayFactory()
         show_context = VolunteerContext()

--- a/tests/gbe/test_edit_profile.py
+++ b/tests/gbe/test_edit_profile.py
@@ -248,8 +248,9 @@ class TestEditProfile(TestCase):
         del(data['first_name'])
         del(data['last_name'])
         response = self.client.post(url, data=data, follow=True)
-        self.assertContains(response, "Your Account")
         self.assertRedirects(response, reverse('home', urlconf='gbe.urls'))
+        assert_alert_exists(
+            response, 'success', 'Success', default_update_profile_msg)
 
     def test_active_user_cant_remove_vitals(self):
         ClassFactory(teacher__contact=self.profile)


### PR DESCRIPTION
The 500 error on copying Main event was caused by copying the rehearsal slot(s).

This is because the code expected 2 labels - the conference slug & the calendar type.  But it only got 1 (the slug) and then got a blank string.  That failed on data persistence, the field for the label can't be empty/null.

Added in a check to see if there IS a calendar type, and everything works fine.

Put in a test, since this is def a sneaky requirement that I will forget about.