### PR TITLE
Gbe 330: label volunteer events with parent title, or parent slug, depending on available space

### DIFF
--- a/gbe/scheduling/views/edit_volunteer_view.py
+++ b/gbe/scheduling/views/edit_volunteer_view.py
@@ -75,9 +75,10 @@ class EditVolunteerView(ManageWorkerView):
             context,
             open_to_public=False)
 
-        context['association_form'] = EventAssociationForm(initial={
-            'staff_area': self.area,
-            'parent_event': self.parent_id})
+        if 'association_form' not in context:
+            context['association_form'] = EventAssociationForm(initial={
+              'staff_area': self.area,
+              'parent_event': self.parent_id})
         context['edit_title'] = self.title
         context['scheduling_form'].fields['approval'].widget = CheckboxInput()
 

--- a/gbe/scheduling/views/show_calendar_view.py
+++ b/gbe/scheduling/views/show_calendar_view.py
@@ -127,10 +127,16 @@ class ShowCalendarView(View):
                 if booking.event == occurrence:
                     role = booking.role
             hour = occurrence.start_time.strftime("%-I:00 %p")
+            title = occurrence.title
+            if occurrence.parent is not None:
+                title = "%s: %s" % (occurrence.parent.title, occurrence.title)
+                if occurrence.parent.slug is not None:
+                    title = "%s: %s" % (occurrence.parent.slug,
+                                        occurrence.title)
             occurrence_detail = {
                 'start':  occurrence.start_time.strftime(GBE_TIME_FORMAT),
                 'end': occurrence.end_time.strftime(GBE_TIME_FORMAT),
-                'title': occurrence.title,
+                'title': title,
                 'location': occurrence.location,
                 'hour': hour,
                 'approval_needed': occurrence.approval_needed,

--- a/gbe/templates/gbe/incl_schedule.tmpl
+++ b/gbe/templates/gbe/incl_schedule.tmpl
@@ -22,7 +22,7 @@
             <i class="fa fa-star" aria-hidden="true"></i></a>
 	    {% endif %}
             {{booking.starttime}}, 
-          <a href="{% url 'scheduling:detail_view' booking.id %}" class="gbe-link">
+          <a href="{% url 'scheduling:detail_view' booking.id %}" class="gbe-link" {% if booking.long %}title="{{booking.long}}"{% endif %}>
             {{ booking.title }}</a>
 	    {% if not historical %}
 	      {% if booking.role == "Teacher" or booking.role == "Moderator" %}

--- a/gbe/templates/gbe/report/printable_schedules.tmpl
+++ b/gbe/templates/gbe/report/printable_schedules.tmpl
@@ -25,7 +25,7 @@
     <th class='printable-header'>Time</th>
   {% for booking in schedule.bookings %}
   <tr class='printable-table {% if booking.role == 'Interested' %}interested-sched{% else %}dedicated-sched{% endif %}'>
-    <td class='printable-table'>{{ booking.event | safe }}</td>
+    <td class='printable-table'>{% if booking.event.parent %}{{ booking.event.parent.title | safe}}: {% endif %}{{ booking.event | safe }}</td>
     <td class='printable-table'>{{booking.role|title}} </td>    
     <td class='printable-table'>{{booking.event.location}} </td>    
     <td class='printable-table'>{{booking.event.starttime.date}} </td>

--- a/gbe/templates/gbe/report/staff_area_schedule.tmpl
+++ b/gbe/templates/gbe/report/staff_area_schedule.tmpl
@@ -26,7 +26,8 @@
 {% for opp in opps%}
 <div class="card round gbe-panel-list mx-2 my-4">
   <div class="card-header gbe-bg-dark">
-    <h2 class="card-title">{{ opp.starttime}} - {{ opp.title}}
+    <h2 class="card-title">{{ opp.starttime}}<br>
+      {% if opp.parent %}{{opp.parent.title}}: {% endif %}{{ opp.title}}
     {% if conference.status != "completed" %}<a href="{% url 'scheduling:edit_event' conference.conference_slug opp.pk %}" role="button" class="btn gbe-btn-primary float-right">Edit</a>{% endif %}</h2></div>
   <div class="card-body"><b>Location:</b>  {{opp.location}}<br>{% if opp.role_count %}Max people: {{opp.role_count}}{% endif %}</div>
   <table class="table gbe-panel-table">

--- a/gbe/templates/gbe/scheduling/event_display_list.tmpl
+++ b/gbe/templates/gbe/scheduling/event_display_list.tmpl
@@ -52,7 +52,7 @@
 <div class="card round gbe-panel-list mx-2 my-4">
   <div class="card-header gbe-bg-dark">
     <h2 class="card-title">
-      <a href='{{event.detail}}' class="gbe-panel-link">{{ event.occurrence.title }}</a>
+      <a href='{{event.detail}}' class="gbe-panel-link">{% if event.occurrence.parent %}{{ event.occurrence.parent.title | safe}}: {% endif %}{{ event.occurrence.title }}</a>
       <div class="pull-right">
 	<a href='{{event.detail}}' class="detail_link" title="More information">
           <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i>

--- a/gbe/templates/gbe/scheduling/event_modal.tmpl
+++ b/gbe/templates/gbe/scheduling/event_modal.tmpl
@@ -1,5 +1,5 @@
 <!-- Event Modal Start -->
-              <div class="modal" id="Modal{{occurrence.pk}}" role="dialog">
+              <div class="modal" id="Modal{{occurrence.object.pk}}" role="dialog">
               <div class="modal-dialog modal-dialog-centered modal-md">
               <div class="modal-content gbe-modal-content">
                 <form action="{{occurrence.volunteer_link}}?next={{ request.get_full_path }}" method="post" enctype="multipart/form-data">

--- a/gbe/templates/gbe/scheduling/volunteer_signup.tmpl
+++ b/gbe/templates/gbe/scheduling/volunteer_signup.tmpl
@@ -60,9 +60,9 @@
   {% for is_hour, hour, time, wrap in grid_list %}
     {% if time == occurrence.object.start_time.time %}
     <td class="vol_shift_event" id="{{occurrence.highlight|slugify}}" colspan="{{occurrence.colspan}}">
-      <a class="gbe-link" href="#" data-toggle="modal" data-target="#Modal{{occurrence.pk}}" data-backdrop="true" >
+      <a class="gbe-link" href="#" data-toggle="modal" data-target="#Modal{{occurrence.object.pk}}" data-backdrop="true" >
     {% include "gbe/scheduling/volunteer_icon.tmpl" with icon_class="volunteer-icon" %}
-    {{ occurrence.start }}-{{ occurrence.end }} <b>{{ occurrence.title}}</b></a>
+    {{ occurrence.start }}-{{ occurrence.end }} <b>{% if occurrence.object.parent and occurrence.object.parent.slug %}{{occurrence.object.parent.slug}}: {% endif %}{{ occurrence.title}}</b></a>
     {% include "gbe/scheduling/event_modal.tmpl"%}
     </td>
       {% if occurrence.object.start_time.time > occurrence.object.end_time.time %}

--- a/gbe/views/landing_page_view.py
+++ b/gbe/views/landing_page_view.py
@@ -104,6 +104,14 @@ class LandingPageView(ProfileRequiredMixin, View):
             calendar_type = calendar_for_event[booking.event.event_style]
             conference = Conference.objects.filter(
                 conference_slug__in=booking.event.labels)[0]
+            title = booking.event.title
+            long_title = None
+            if booking.event.parent is not None:
+                long_title = "%s: %s" % (booking.event.parent.title,
+                                         booking.event.title)
+                if booking.event.parent.slug is not None:
+                    title = "%s: %s" % (booking.event.parent.slug,
+                                        booking.event.title)
             booking_item = {
                 'id': booking.event.pk,
                 'role':  booking.role,
@@ -112,7 +120,8 @@ class LandingPageView(ProfileRequiredMixin, View):
                 'interested': get_bookings(
                     [booking.event.pk],
                     roles=["Interested"]).people,
-                'title': booking.event.title, }
+                'title': title,
+                'long': long_title}
 
             if calendar_type == "Conference" and (
                     booking.role not in ("Teacher", "Performer", "Moderator")):

--- a/tests/gbe/reports/test_welcome_letter.py
+++ b/tests/gbe/reports/test_welcome_letter.py
@@ -15,7 +15,10 @@ from tests.factories.ticketing_factories import (
     TransactionFactory,
     TicketingEligibilityConditionFactory
 )
-from tests.contexts import ClassContext
+from tests.contexts import (
+    ClassContext,
+    VolunteerContext,
+)
 from tests.functions.gbe_functions import (
     grant_privilege,
     login_as
@@ -89,6 +92,22 @@ class TestWelcomeLetter(TestCase):
             response,
             str(context.room))
         self.assertContains(response, "dedicated-sched")
+
+    def test_personal_schedule_volunteer_w_slug(self):
+        '''a teacher booked into a class, with an active role condition
+           should have a booking
+        '''
+        context = VolunteerContext()
+
+        login_as(self.priv_profile, self)
+        response = self.client.get(
+            self.url,
+            data={"conf_slug": context.conference.conference_slug})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, str(context.profile))
+        self.assertContains(response, "%s: %s" % (
+            context.sched_event.title,
+            context.opp_event.title))
 
     def test_personal_schedule_interest_booking(self):
         '''a teacher booked into a class, with an active role condition

--- a/tests/gbe/scheduling/test_calendar_view.py
+++ b/tests/gbe/scheduling/test_calendar_view.py
@@ -278,7 +278,9 @@ class TestCalendarView(TestCase):
             response,
             "There are no general events scheduled for this day.")
 
-    def test_calendar_1_event_per_hour(self):
+    def test_calendar_1_event_per_hour_w_parent(self):
+        self.volunteeropp.parent = self.showcontext.sched_event
+        self.volunteeropp.save()
         url = reverse('calendar',
                       urlconf="gbe.scheduling.urls",
                       args=['Volunteer'])
@@ -287,9 +289,16 @@ class TestCalendarView(TestCase):
             response,
             '<div class="col-lg-12 col-md-12 col-sm-12 col-12">',
             1)
+        self.assertContains(response, self.showcontext.sched_event.slug)
+        self.assertNotContains(response, self.showcontext.sched_event.title)
 
     def test_calendar_2_event_per_hour(self):
+        other_show = ShowContext(conference=self.other_conference)
+        other_show.sched_event.slug = None
+        other_show.sched_event.save()
         two_opp = self.staffcontext.add_volunteer_opp()
+        two_opp.parent = other_show.sched_event
+        two_opp.save()
         url = reverse('calendar',
                       urlconf="gbe.scheduling.urls",
                       args=['Volunteer'])
@@ -299,6 +308,7 @@ class TestCalendarView(TestCase):
             '<div class="col-lg-6 col-md-6 col-sm-6 col-12">',
             2)
         self.assertContains(response, two_opp.title)
+        self.assertContains(response, other_show.sched_event.title)
 
     def test_calendar_3_event_per_hour(self):
         self.staffcontext.add_volunteer_opp()

--- a/tests/gbe/scheduling/test_edit_volunteer.py
+++ b/tests/gbe/scheduling/test_edit_volunteer.py
@@ -262,6 +262,30 @@ class TestEditVolunteer(TestGBE):
                     GBE_DATETIME_FORMAT)),
             html=True)
 
+    def test_edit_event_error_w_change_parent(self):
+        other_context = VolunteerContext(conference=self.context.conference)
+        grant_privilege(self.privileged_user, 'Volunteer Coordinator')
+        login_as(self.privileged_user, self)
+        data = self.edit_event()
+        data['title'] = ""
+        data['parent_event'] = other_context.sched_event.pk
+        data['edit_event'] = "Save and Continue"
+        response = self.client.post(
+            self.url,
+            data=data,
+            follow=True)
+        self.assertContains(
+            response,
+            "This field is required.")
+        self.assertContains(
+            response,
+            '<option value="%d" selected>%s - %s</option>' % (
+                other_context.sched_event.pk,
+                other_context.sched_event.title,
+                other_context.sched_event.start_time.strftime(
+                    GBE_DATETIME_FORMAT)),
+            html=True)
+
     def test_edit_event_set_area(self):
         other_context = StaffAreaContext(conference=self.context.conference)
         grant_privilege(self.privileged_user, 'Volunteer Coordinator')

--- a/tests/gbe/scheduling/test_list_events.py
+++ b/tests/gbe/scheduling/test_list_events.py
@@ -183,6 +183,7 @@ class TestViewList(TestCase):
         this_class = ClassFactory.create(accepted=3,
                                          b_conference=self.conf)
         staff_context = StaffAreaContext(conference=self.conf)
+        volunteer_context = VolunteerContext(conference=self.conf)
         opportunity = staff_context.add_volunteer_opp()
         opportunity.starttime = datetime.now() + timedelta(days=1)
         opportunity.save()
@@ -198,6 +199,9 @@ class TestViewList(TestCase):
                            urlconf='gbe.scheduling.urls')
         self.assertContains(response, opportunity.title)
         self.assertContains(response, vol_link)
+        self.assertContains(response, "%s: %s" % (
+            volunteer_context.sched_event.title,
+            volunteer_context.opp_event.title))
         self.assertContains(response,
                             'volunteered.gif" class="volunteer-icon"')
         self.assertNotContains(response, this_class.b_title)

--- a/tests/gbe/scheduling/test_volunteer_signup_view.py
+++ b/tests/gbe/scheduling/test_volunteer_signup_view.py
@@ -282,6 +282,9 @@ class TestVolunteerSignupView(TestCase):
             "volunteered.gif",
             action="off")
         self.assertContains(response, vol_context.sched_event.title)
+        self.assertContains(response, "%s: %s" % (
+            vol_context.sched_event.slug,
+            vol_context.opp_event.title))
         self.assertContains(response, reverse(
             "detail_view",
             urlconf="gbe.scheduling.urls",

--- a/tests/gbe/test_landing_page.py
+++ b/tests/gbe/test_landing_page.py
@@ -583,6 +583,8 @@ class TestIndex(TestCase):
 
     def test_staff_lead_button(self):
         show_context = ActTechInfoContext(schedule_rehearsal=True)
+        show_context.sched_event.slug = "Iamashowslug"
+        show_context.sched_event.save()
         vol_context = VolunteerContext(sched_event=show_context.sched_event)
         context = StaffAreaContext(conference=show_context.conference)
         EventLabelFactory(event=vol_context.opp_event,
@@ -597,6 +599,14 @@ class TestIndex(TestCase):
             'show_dashboard',
             urlconf='gbe.scheduling.urls',
             args=[show_context.sched_event.pk]))
+        self.assertContains(
+            response,
+            "%s: %s" % (show_context.sched_event.title,
+                        vol_context.opp_event.title))
+        self.assertContains(
+            response,
+            "%s: %s" % (show_context.sched_event.slug,
+                        vol_context.opp_event.title))
 
     def test_no_act_tech_alert(self):
         current_act_context = ActTechInfoContext(


### PR DESCRIPTION
This is the actual goal of #330 - that when we have a volunteer event that is part of a parent, the volunteer event is always labeled with the parent's title, since that is always relevant.  No one is just "follow spot operator" - they are "Main Event: Follow Spot Operator" or if the real estate is small "ME: Follow Spot Operator" - so now we don't need to label everything with "ME -" at the start of the event title.

This takes a couple of forms:
- in table views, the parent is it's own cell, so it can easily be a separate sort/search thing.
- in bigger headers and the welcome letter, this is written out the long way (ie - "Main Event")
- in places where the parent event was already noted (event detail pages, and the blurb associated with the volunteer role) - I changed nothing
- in places with very small space (calendars, home page) - we use the parent's slug - "ME" - which will have to be manually set after this fix goes out

If there is no parent (or in cases were there must be a slug, no slug), the event still shows up as before - just the title.

Also fixed a bug in the volunteer schedule display that came from #334 and a bug in scheduling error handling that has always been there.

Not quite ready to pull yet - I need to update test cases.