### PR TITLE
GBE-347: can't copy rehearsal with edit event, also had copy bug

### DIFF
--- a/gbe/scheduling/views/copy_occurrence_view.py
+++ b/gbe/scheduling/views/copy_occurrence_view.py
@@ -114,7 +114,7 @@ class CopyOccurrenceView(CopyCollectionsView):
             max_volunteer=occurrence.max_volunteer,
             max_commitments=occurrence.max_commitments,
             locations=[new_event_room],
-            description=occurrence.duration,
+            description=occurrence.description,
             parent_event_id=parent_event_id,
             labels=labels,
             approval=occurrence.approval_needed,

--- a/gbe/scheduling/views/edit_event_view.py
+++ b/gbe/scheduling/views/edit_event_view.py
@@ -99,6 +99,8 @@ class EditEventView(ManageVolWizardView):
         validity = False
         for form in formset:
             validity = form.is_valid() or validity
+        if len(formset) == 0:
+            validity = True
         return validity
 
     def make_context(self, request, errorcontext=None):


### PR DESCRIPTION
Found and fixed #347 - the problem was a long-standing issue with validation - because the rehearsal slot doesn't have any staff roles automatically affiliated, the worker form validation returned false (and should be true), so everything failed, but it failed silently, since there was no actual form error to report.

In doing that, I saw a copy error - all the volunteer slots and rehearsal slots copied recently, the duration was saved as the description.  That was a recent refactor bug, that's exactly what the code was doing.  Fixed this too.