### PR TITLE
GBE-349 make a "mail merge" switch on the casting of the person into the role

### DIFF
--- a/gbe/email/functions.py
+++ b/gbe/email/functions.py
@@ -116,7 +116,8 @@ def send_bid_state_change_mail(
         badge_name,
         bid,
         status,
-        show=None):
+        show=None,
+        casting=None):
     site = Site.objects.get_current()
     context = {
         'name': badge_name,
@@ -125,6 +126,8 @@ def send_bid_state_change_mail(
         'status': acceptance_states[status][1],
         'site': site.domain,
         'site_name': site.name}
+    if casting:
+        context['casting'] = casting
     if show:
         name = '%s %s - %s' % (
             bid_type.lower(),

--- a/gbe/templates/gbe/email/default_bid_status_change.tmpl
+++ b/gbe/templates/gbe/email/default_bid_status_change.tmpl
@@ -1,8 +1,6 @@
 Dear {{ name }},
 
-The status of your {{ bid_type }} - {{ bid }} - has been changed to {{ status }}. You can
-always check the status of your submissions or your schedule by visiting
-your personal pane on {{site}}.
+The status of your {{ bid_type }} - {{ bid }} - has been changed to {{ status }}. {% if casting %}Your role is {{ casting }}{% endif %}.  You can always check the status of your submissions or your schedule by visiting your personal pane on {{site}}.
 
 {% if show %}
 Congratulations!  Your act, {{ bid }} was cast in {{ show }}.  We've posted you as one of

--- a/gbe/templates/gbe/email/default_bid_status_change_html.tmpl
+++ b/gbe/templates/gbe/email/default_bid_status_change_html.tmpl
@@ -1,8 +1,7 @@
 Dear {{ name }},
 <br><br>
 
-The status of your {{ bid_type }} has been changed to {{ status }}. You can
-always check the status of your submissions or your schedule by visiting
+The status of your {{ bid_type }} has been changed to {{ status }}.  {% if casting %}Your role is {{ casting }}.  {% endif %}You can always check the status of your submissions or your schedule by visiting
 your personal pane on <a href='{{site}}'>{{site_name}}</a>
 <br><br>
 

--- a/tests/gbe/test_act_changestate.py
+++ b/tests/gbe/test_act_changestate.py
@@ -385,6 +385,7 @@ class TestActChangestate(TestCase):
             'act accepted - %s' % self.sched_event.title.lower(),
             "Your act has been cast in %s" % self.sched_event.title
         )
+        assert_email_contents("Regular Act")
         casting = Ordering.objects.get(
             class_id=new_context.act.pk,
             allocation__event=self.sched_event)


### PR DESCRIPTION
We actually already have "Regular Act" and "Non-compete" in the system - the term in our data is "ActCastingOption" in the admin.  In the act acceptance, we called it "Section".

Now, when the act is accepted, the email template sent to them can make use of the term "casting".  And the email can do stuff like {% if casting=="Regular Act" %}You are a regular act, here is stuff for you!{% endif %}.  "casting" is a string where the value of the string is the value seen in the drop down for "Section" on the act casting page.

I also updated the default template with some logic to show the use of casting.  You can see the default by deleting any template and then accepting an act.

