### PR TITLE
GBE-352:  Show email on act review

### DIFF
--- a/gbe/views/review_flex_bid_view.py
+++ b/gbe/views/review_flex_bid_view.py
@@ -102,6 +102,7 @@ class FlexibleReviewBidView(ReviewBidView):
             'review_results': self.review_results,
             'reviewers': self.reviewers,
             'notes': self.notes,
+            'display_contact_info': True,
              })
         return render(
             request,

--- a/tests/gbe/test_review_act.py
+++ b/tests/gbe/test_review_act.py
@@ -84,6 +84,9 @@ class TestReviewAct(TestCase):
         self.assertContains(response, 'Act Proposal')
         self.assertContains(response, 'Review Act')
         self.assertContains(response, self.act.performer.experience)
+        self.assertContains(
+            response,
+            self.act.performer.performer_profile.user_object.email)
 
     def test_hidden_fields_are_populated(self):
         login_as(self.privileged_user, self)


### PR DESCRIPTION
It turns out, we have a switch for "display contact info" on the review form.  I turned it on.

It makes a set of contact information, including email & phone & location at the bottom of the act submission info.

2 lines of code - 1 to test, 1 to change