### PR TITLE
Gbe 345: fix comp act flow

### DIFF
--- a/gbe/forms/act_coordination_form.py
+++ b/gbe/forms/act_coordination_form.py
@@ -25,7 +25,6 @@ class ActCoordinationForm(ModelForm):
     track_artist = CharField(required=False)
     track_title = CharField(required=False)
     b_conference = HiddenInput()
-    accepted = IntegerField(widget=HiddenInput(), initial=3)
     b_description = CharField(
         required=True,
         label=act_bid_labels['description'],
@@ -41,8 +40,7 @@ class ActCoordinationForm(ModelForm):
             'track_artist',
             'act_duration',
             'b_description',
-            'b_conference',
-            'accepted']
+            'b_conference']
         labels = act_bid_labels
         help_texts = act_help_texts
         widgets = {

--- a/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -4,7 +4,13 @@
     <h2 class="gbe-title">{{view_title}}</h2>
     <h3>{{conference}}</h3>
    </div><div class="col-md-4 text-right">
-    {% if perms.gbe.assign_act %}<a href="{% url 'gbe:act_coord_create' %}" role="button" class="btn gbe-btn-primary">Create Approved Act</a>{% endif %}
+    {% if perms.gbe.assign_act %}
+    <div class="dropdown show">
+      <a class="btn gbe-btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Comp Act Options</a>
+      <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+        <a class="dropdown-item" href="{% url 'gbe:act_coord_create' %}">Create & Comp Act</a>
+        <a class="dropdown-item" href="#">Send a Comp</a>
+      </div></div>{% endif %}
   </div></div>
  {% endblock %}
 {% block tbody %}

--- a/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -9,7 +9,7 @@
       <a class="btn gbe-btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Comp Act Options</a>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
         <a class="dropdown-item" href="{% url 'gbe:act_coord_create' %}">Create & Comp Act</a>
-        <a class="dropdown-item" href="#">Send a Comp</a>
+        <a class="dropdown-item" href="{% url 'ticketing:comp_ticket' %}">Send a Comp</a>
       </div></div>{% endif %}
   </div></div>
  {% endblock %}

--- a/gbe/templates/gbe/bid.tmpl
+++ b/gbe/templates/gbe/bid.tmpl
@@ -36,7 +36,7 @@
      {% if fee_paid %}
      <input type="submit" name="submit" value="{% if submit_button %}{{submit_button}}{% else %}Submit For Approval{% endif %}" class="btn gbe-btn-primary">
      {% else %}
-     <input type="submit" name="submit" formnovalidate value="Proceed to Payment" class="btn gbe-btn-primary">
+     <input type="submit" name="submit" formnovalidate value="{% if submit_button %}{{submit_button}}{% else %}Proceed to Payment{% endif %}" class="btn gbe-btn-primary">
      {% endif %}
    {% endif %}
    </form>

--- a/gbe/templates/gbe/bid.tmpl
+++ b/gbe/templates/gbe/bid.tmpl
@@ -34,7 +34,7 @@
    {% else %}
    <input type="submit" name="draft" formnovalidate value="Save Draft" class="btn gbe-btn-secondary">
      {% if fee_paid %}
-     <input type="submit" name="submit" value="Submit For Approval" class="btn gbe-btn-primary">
+     <input type="submit" name="submit" value="{% if submit_button %}{{submit_button}}{% else %}Submit For Approval{% endif %}" class="btn gbe-btn-primary">
      {% else %}
      <input type="submit" name="submit" formnovalidate value="Proceed to Payment" class="btn gbe-btn-primary">
      {% endif %}

--- a/gbe/views/coordinate_act_view.py
+++ b/gbe/views/coordinate_act_view.py
@@ -1,5 +1,8 @@
 from gbe.views import MakeActView
-from django.urls import reverse
+from django.urls import (
+    reverse,
+    reverse_lazy,
+)
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from gbe.models import TechInfo
 from gbe.forms import ActCoordinationForm
@@ -16,11 +19,13 @@ from django.contrib import messages
 class CoordinateActView(PermissionRequiredMixin, MakeActView):
     page_title = 'Create Act for Coordinator'
     view_title = 'Book an Act'
-    has_draft = False
+    has_draft = True
     permission_required = 'gbe.assign_act'
     submit_form = ActCoordinationForm
+    draft_form = ActCoordinationForm
     coordinated = True
     instructions = act_coord_instruct
+    normal_redirect = reverse_lazy('act_review', urlconf='gbe.urls')
 
     def groundwork(self, request, args, kwargs):
         # do the basic bid stuff, but NOT the regular act stuff
@@ -52,7 +57,7 @@ class CoordinateActView(PermissionRequiredMixin, MakeActView):
 
     def make_context(self, request):
         context = super(MakeActView, self).make_context(request)
-        context['nodraft'] = "Submit & Proceed to Casting"
+        context['submit_button'] = "Submit & Review"
         return context
 
     def submit_bid(self, request):

--- a/gbe/views/coordinate_act_view.py
+++ b/gbe/views/coordinate_act_view.py
@@ -25,7 +25,7 @@ class CoordinateActView(PermissionRequiredMixin, MakeActView):
     draft_form = ActCoordinationForm
     coordinated = True
     instructions = act_coord_instruct
-    normal_redirect = reverse_lazy('act_review', urlconf='gbe.urls')
+    normal_redirect = reverse_lazy('act_review_list', urlconf='gbe.urls')
 
     def groundwork(self, request, args, kwargs):
         # do the basic bid stuff, but NOT the regular act stuff

--- a/gbe/views/make_bid_view.py
+++ b/gbe/views/make_bid_view.py
@@ -5,7 +5,10 @@ from django.views.decorators.cache import never_cache
 from gbe_utils.mixins import SubwayMapMixin
 from django.contrib import messages
 from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.urls import (
+    reverse,
+    reverse_lazy,
+)
 from django.http import Http404
 from django.shortcuts import (
     get_object_or_404,
@@ -41,6 +44,7 @@ class MakeBidView(SubwayMapMixin, View):
     instructions = ''
     payment_form = None
     coordinated = False
+    normal_redirect = reverse_lazy('home', urlconf='gbe.urls')
 
     def groundwork(self, request, args, kwargs):
         self.owner = validate_profile(request, require=False)
@@ -324,7 +328,7 @@ class MakeBidView(SubwayMapMixin, View):
 
         messages.success(request, user_message[0].description)
         return HttpResponseRedirect(
-            redirect or reverse('home', urlconf='gbe.urls'))
+            redirect or self.normal_redirect)
 
     def dispatch(self, *args, **kwargs):
         return super(MakeBidView, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
#345 

1 - changed the Act Review List button for comping acts into a menu w. two options:
 - a link to just giving a free act submission token to a given profile (also on manage->transactions page)
 - a link to creating an act for a give performer (what was there before)

2 - change the create act for performer flow so that:
- you can save a draft version & give a comp token - it requires the performer, the title and the description and then the act draft shows up on their page so they can give the rest of the details and submit w/out paying.
- you can save and submit the act - it gets comp'ed and then put into Needs Review state - then you are directed to the act review page to cast it into a show (or not...) - if you cancel out of that page, the act stays in submitted but in need of review.  

Pepdiff = good
Coverage = same