### PR TITLE
GBE-359: Fix bug in volunteer create

### DIFF
--- a/gbe/scheduling/forms/volunteer_opportunity_form.py
+++ b/gbe/scheduling/forms/volunteer_opportunity_form.py
@@ -1,9 +1,17 @@
-from django.forms import BooleanField
+from django.forms import (
+    BooleanField,
+    CharField,
+    HiddenInput,
+)
 from gbe.scheduling.forms import ScheduleBasicForm
 
 
 class VolunteerOpportunityForm(ScheduleBasicForm):
     approval = BooleanField(initial=False, required=False)
+    event_style = CharField(
+        widget=HiddenInput(),
+        required=True,
+        initial="Volunteer")
 
     class Meta:
         fields = ['title',

--- a/tests/gbe/scheduling/test_edit_show_view.py
+++ b/tests/gbe/scheduling/test_edit_show_view.py
@@ -92,11 +92,15 @@ class TestEditShowWizard(TestCase):
             response,
             'class="panel-collapse collapse show"',
             3)
-        print(response.content)
         self.assertContains(
             response,
             '<input type="hidden" name="new_opp-event_style" value="Volunteer"'
             ' id="id_new_opp-event_style">',
+            html=True)
+        self.assertContains(
+            response,
+            '<input type="hidden" name="new_slot-event_style" value='
+            '"Rehearsal Slot" id="id_new_slot-event_style">',
             html=True)
 
     def test_good_user_get_rehearsal_w_acts(self):

--- a/tests/gbe/scheduling/test_edit_show_view.py
+++ b/tests/gbe/scheduling/test_edit_show_view.py
@@ -92,6 +92,12 @@ class TestEditShowWizard(TestCase):
             response,
             'class="panel-collapse collapse show"',
             3)
+        print(response.content)
+        self.assertContains(
+            response,
+            '<input type="hidden" name="new_opp-event_style" value="Volunteer"'
+            ' id="id_new_opp-event_style">',
+            html=True)
 
     def test_good_user_get_rehearsal_w_acts(self):
         act_techinfo_context = ActTechInfoContext(


### PR DESCRIPTION
The volunteer new-opportunity bit of these forms used the data in the generic child scheduler.  That logic had to default to something - the default was Rehearsal Slot.  This is a presentation-side bug - the data is hidden in the web page when the user makes the volunteer slot.  So, all the tests of submission passed - since you can _make_ a volunteer opportunity... but it's not what you are doing when you actually use the system.

Fortunately, we have a place to fix the data that gets presented on these pages.  Once the initial data was to make "Volunteer", all was well.

Tested manually, and added a condition to the edit show tests to make sure we present this data properly.