### PR TITLE
Gbe 348: Filter for show preferences

### DIFF
--- a/gbe/admin.py
+++ b/gbe/admin.py
@@ -49,7 +49,6 @@ class ActAdmin(BidAdmin):
                     'b_title',
                     'submitted',
                     'accepted',
-                    'shows_preferences',
                     'created_at',
                     'updated_at')
     search_fields = ['b_title', 'performer__name']

--- a/gbe/admin.py
+++ b/gbe/admin.py
@@ -49,6 +49,7 @@ class ActAdmin(BidAdmin):
                     'b_title',
                     'submitted',
                     'accepted',
+                    'shows_preferences',
                     'created_at',
                     'updated_at')
     search_fields = ['b_title', 'performer__name']

--- a/gbe/auth/email_username_auth.py
+++ b/gbe/auth/email_username_auth.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth import get_user_model
-from django.db.models import Q
 
 
 class EmailUsernameAuth(ModelBackend):

--- a/gbe/forms/__init__.py
+++ b/gbe/forms/__init__.py
@@ -29,6 +29,7 @@ from .act_edit_form import (
     ActEditForm,
 )
 from .act_coordination_form import ActCoordinationForm
+from .act_filter_form import ActFilterForm
 from .class_bid_form import (
     ClassBidDraftForm,
     ClassBidForm,

--- a/gbe/forms/act_filter_form.py
+++ b/gbe/forms/act_filter_form.py
@@ -1,0 +1,17 @@
+from django.forms import (
+    CheckboxSelectMultiple,
+    Form,
+    MultipleChoiceField,
+)
+from gbetext import act_shows_options_short
+
+
+class ActFilterForm(Form):
+    required_css_class = 'required'
+    error_css_class = 'error'
+    shows_preferences = MultipleChoiceField(
+        widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
+        choices=act_shows_options_short,
+        label="Preferred Shows",
+        required=False
+    )

--- a/gbe/functions.py
+++ b/gbe/functions.py
@@ -21,7 +21,6 @@ from gbe_utils.text import no_profile_msg
 import json
 import urllib
 from settings import GBE_DATETIME_FORMAT
-from django.db.models import Q
 import xml.etree.ElementTree as et
 import html
 from gbe_logging import logger

--- a/gbe/templates/gbe/gbe_table.tmpl
+++ b/gbe/templates/gbe/gbe_table.tmpl
@@ -17,8 +17,23 @@
   <div>Press the arrows to sort on a column.  To sort on an additional sub-order,
   press "Shift" to sort a secondary column.</div>
   <br/>
+  {% if filter_form %}
+  <div class="card round gbe-panel-list mx-2 my-4">
+  <div class="card-header gbe-bg-light">
+  <form action="" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {% for field in filter_form.visible_fields %}
+    <div class="row email-select">
+      {% include "gbe/email/filter_checkbox_horizontal.tmpl" %}
+    </div>
+    <div>
+    <input type="submit" class="btn gbe-btn-secondary float-right" name="filter" value="Filter Interest">
+    </div>
+    {% endfor %} 
+  </form></div></div>
+  {% endif %}
   <div>
-    Toggle column(s):
+    <b>Toggle column(s):</b>
     {% for column in columns %}
     <button type="button" class="btn btn-sm gbe-btn-secondary toggle-vis" data-toggle="button" aria-pressed="false" autocomplete="off" data-column="{{ forloop.counter0 }}">{{column}}</button>
     {% endfor %}

--- a/gbe/views/review_bid_list_view.py
+++ b/gbe/views/review_bid_list_view.py
@@ -25,7 +25,10 @@ class ReviewBidListView(View):
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
-        return super(ReviewBidListView, self).dispatch(*args, **kwargs)
+        try:
+            return super(ReviewBidListView, self).dispatch(*args, **kwargs)
+        except IndexError:
+            return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
 
     def get_bids(self, request=None):
         return self.object_type.objects.filter(
@@ -118,10 +121,7 @@ class ReviewBidListView(View):
         if request.GET.get('changed_id'):
             self.changed_id = int(request.GET['changed_id'])
 
-        try:
-            self.get_bid_list()
-        except IndexError:
-            return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
+        self.get_bid_list()
 
         return render(request,
                       self.template,
@@ -130,12 +130,7 @@ class ReviewBidListView(View):
     @never_cache
     def post(self, request, *args, **kwargs):
         self.groundwork(request)
-
-        try:
-            self.get_bid_list(request)
-        except IndexError:
-            return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
-
+        self.get_bid_list(request)
         return render(request,
                       self.template,
                       self.get_context_dict())

--- a/gbe/views/review_bid_list_view.py
+++ b/gbe/views/review_bid_list_view.py
@@ -21,6 +21,7 @@ class ReviewBidListView(View):
     template = 'gbe/bid_review_list.tmpl'
     bid_order_fields = ('accepted', 'b_title')
     status_index = 4
+    changed_id = -1
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
@@ -116,11 +117,9 @@ class ReviewBidListView(View):
 
         if request.GET.get('changed_id'):
             self.changed_id = int(request.GET['changed_id'])
-        else:
-            self.changed_id = -1
 
         try:
-            self.get_bid_list(request)
+            self.get_bid_list()
         except IndexError:
             return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
 
@@ -133,7 +132,7 @@ class ReviewBidListView(View):
         self.groundwork(request)
 
         try:
-            self.get_bid_list()
+            self.get_bid_list(request)
         except IndexError:
             return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
 

--- a/gbetext.py
+++ b/gbetext.py
@@ -66,7 +66,8 @@ ACT_INCOMPLETE_NOT_SUBMITTED = ("This act is not complete and cannot be "
                                 "submitted for a show.")
 ACT_INCOMPLETE_NOT_SUBMITTED = ("This act is not complete but it has been "
                                 "submitted for a show.")
-
+no_filter_msg = ("The filter applied to this list did not work.  All "
+                 "results are displayed.")
 act_shows_options = [
     (4, mark_safe('Thursday, May 4, 8PM: <b>Star Bras!</b><br><small>Show us '
                   'your space opera! Visitors from any planet (or universe) '
@@ -83,6 +84,13 @@ act_shows_options = [
     (7, mark_safe('Saturday, May 6, 9PM: <b>The Main Event, competition</b>'
                   '<br><small>Bring us your best act to compete for titles, '
                   'prizes, and cash!</small>'))]
+act_shows_options_short = [
+    (4, mark_safe('<b>Star Bras!</b><br>Thursday, May 4, 8PM')),
+    (5, mark_safe('<b>The Burlesk Bordello</b><br>Friday, May 5, 9:30PM')),
+    (6, mark_safe('<b>The Main Event, not in competition</b><br>Saturday, '
+                  'May 6, 7:30PM')),
+    (7, mark_safe('<b>The Main Event, competition</b><br>Saturday, '
+                  'May 6, 9PM'))]
 old_act_shows_options = [(0, 'The Bordello (Fri. Late)'),
                          (1, 'The Main Event, in competition'),
                          (2, 'The Main Event, not in competition'),

--- a/gbetext.py
+++ b/gbetext.py
@@ -68,6 +68,10 @@ ACT_INCOMPLETE_NOT_SUBMITTED = ("This act is not complete but it has been "
                                 "submitted for a show.")
 no_filter_msg = ("The filter applied to this list did not work.  All "
                  "results are displayed.")
+clear_filter_msg = ("The filter has been cleared (no choices made = all "
+                    "options are shown)")
+apply_filter_msg = ("Results have been filtered.  Note, entries with an " +
+                    "empty value are included in all search resulrts.")
 act_shows_options = [
     (4, mark_safe('Thursday, May 4, 8PM: <b>Star Bras!</b><br><small>Show us '
                   'your space opera! Visitors from any planet (or universe) '


### PR DESCRIPTION
#348 implemented

I did a fair amount of the logic in the parent review_bid_list view, so that it could be leveraged by other reviews as needed.  But that also means that any review can now post AND get - and should get the same behavior either way (minus the changed id feature, which is get-only)

Act list view filtering works as:
- any act with a show preference in the filter is in the resuts
- any act with NO preference is in all the results
- there are 3 feedback messages when filtering is done:
   - filter applied
   - filter cleared (ie, a filter request with NO options selected = all bids shown)
   - filter is broken and was not applied (should be impossible unless you hack my forms)

