### PR TITLE
Gbe 386: volunteer review should be limited to Volunteer events

### DIFF
--- a/gbe/scheduling/views/approve_volunteer_view.py
+++ b/gbe/scheduling/views/approve_volunteer_view.py
@@ -57,7 +57,7 @@ class ApproveVolunteerView(View):
     def get_list(self, request):
         pending = get_people(
             roles=["Pending Volunteer", "Waitlisted", "Rejected"],
-            labels=[self.conference.conference_slug])
+            label_sets=[[self.conference.conference_slug], ["Volunteer"]])
         show_general_status(request, pending, self.__class__.__name__)
         rows = []
         action = ""


### PR DESCRIPTION
bug came from recent refactor of events to a flatter database structure

correctly filter waitlisted person assignment so that only those associated with volunteer events are reviewable.