### PR TITLE
Gbe 341: let volunteers start from event views

### DIFF
--- a/gbe/scheduling/views/event_detail_view.py
+++ b/gbe/scheduling/views/event_detail_view.py
@@ -87,7 +87,6 @@ class EventDetailView(View):
             'evaluate': evaluate,
             'approval_needed': eventitem_view['occurrence'].approval_needed,
             'vol_disable_msg': vol_disable_msg,
-            'complete_profile_form': complete_profile_form,
             }]
         template = 'gbe/scheduling/event_detail.tmpl'
         bid = None
@@ -111,7 +110,8 @@ class EventDetailView(View):
             'user_id': request.user.id,
             'bid': bid,
             'schedule_items': schedule_items,
-            'pending_note': pending_instructions[0].description})
+            'pending_note': pending_instructions[0].description,
+            'complete_profile_form': complete_profile_form})
 
     def dispatch(self, *args, **kwargs):
         return super(EventDetailView, self).dispatch(*args, **kwargs)

--- a/gbe/scheduling/views/list_events_view.py
+++ b/gbe/scheduling/views/list_events_view.py
@@ -30,6 +30,7 @@ from gbe_forms_text import (
 from gbetext import (
     calendar_for_event,
     class_styles,
+    login_please,
     role_options,
     pending_note,
 )
@@ -62,12 +63,19 @@ class ListEventsView(View):
             defaults={
                 'summary': "Pending Instructions (in modal, approval needed)",
                 'description': pending_note})
+        login_please_msg = UserMessage.objects.get_or_create(
+            view=self.__class__.__name__,
+            code="LOGIN_REQUIRED",
+            defaults={
+                'summary': "Login or setup account message",
+                'description': login_please})
         context = {
             'conf_slug': self.conference.conference_slug,
             'conference_slugs': conference_slugs(),
             'title': list_titles.get(self.event_type.lower(), ""),
             'view_header_text': list_text.get(self.event_type.lower(), ""),
             'pending_note': pending_instructions[0].description,
+            'login_please': login_please_msg[0].description,
         }
 
         return context

--- a/gbe/scheduling/views/show_calendar_view.py
+++ b/gbe/scheduling/views/show_calendar_view.py
@@ -7,6 +7,7 @@ from django.http import Http404
 from django.urls import reverse
 from gbetext import calendar_type as calendar_type_options
 from gbetext import (
+    login_please,
     pending_note,
     role_options,
 )
@@ -96,12 +97,19 @@ class ShowCalendarView(View):
             defaults={
                 'summary': "Pending Instructions (in modal, approval needed)",
                 'description': pending_note})
+        login_please_msg = UserMessage.objects.get_or_create(
+            view=self.__class__.__name__,
+            code="LOGIN_REQUIRED",
+            defaults={
+                'summary': "Login or setup account message",
+                'description': login_please})
         context = {
             'calendar_type': self.calendar_type,
             'conference': self.conference,
             'conference_slugs': conference_slugs(),
             'this_day': self.this_day,
             'pending_note': pending_instructions[0].description,
+            'login_please': login_please_msg[0].description,
         }
         if self.calendar_type == "General" and validate_perms(
                 request,

--- a/gbe/scheduling/views/show_calendar_view.py
+++ b/gbe/scheduling/views/show_calendar_view.py
@@ -156,6 +156,7 @@ class ShowCalendarView(View):
                 'object': occurrence,
                 'hour': hour,
                 'approval_needed': occurrence.approval_needed,
+                'title': title,
                 'detail_link': reverse('detail_view',
                                        urlconf='gbe.scheduling.urls',
                                        args=[occurrence.pk]),

--- a/gbe/templates/gbe/scheduling/calendar.tmpl
+++ b/gbe/templates/gbe/scheduling/calendar.tmpl
@@ -51,13 +51,13 @@
   {% endifchanged %}
     <div class="col-lg-{{grid_size}} col-md-{% if grid_size > 4 %}{{grid_size}}{% else %}4{% endif %} col-sm-{% if grid_size > 6 %}{{grid_size}}{% else %}6{% endif %} col-12{% if occurrence.highlight %} {{occurrence.highlight|slugify}}{% endif %}">
      {% include "gbe/scheduling/favorite_star.tmpl" with sched_event=occurrence %}
-      {% include "gbe/scheduling/volunteer_link_display.tmpl" with sched_event=occurrence icon_class="volunteer-icon" %}
+      {% include "gbe/scheduling/volunteer_link_display.tmpl" with sched_event=occurrence occurrence=occurrence.object icon_class="volunteer-icon" %}
      {% include "gbe/scheduling/evaluate_icon.tmpl" with evaluate=occurrence.evaluate %}
-     {{ occurrence.start }}-{{ occurrence.end }}<br>
-     <b><a href="{{occurrence.detail_link}}" class="detail_link">{{ occurrence.title}}</a></b><br>
+     {{ occurrence.object.start_time|date:"g:i A" }}-{{ occurrence.object.end_time|date:"g:i A" }}<br>
+     <b><a href="{{occurrence.detail_link}}" class="detail_link">{{ occurrence.object.title}}</a></b><br>
      {% for role, teacher in occurrence.teachers %}{{ role }}:  {{ teacher.name }}
      {% if not forloop.last %}, {% endif %}{% endfor %}<br>
-     <i>{{ occurrence.location }}</i>
+     <i>{{ occurrence.object.location }}</i>
      {% if occurrence.show_dashboard %}
        <a href="{{occurrence.show_dashboard}}" class="btn gbe-btn-secondary btn-sm mb-2 float-right">Dashboard</a>{% endif %}
     </div>

--- a/gbe/templates/gbe/scheduling/calendar.tmpl
+++ b/gbe/templates/gbe/scheduling/calendar.tmpl
@@ -54,7 +54,7 @@
       {% include "gbe/scheduling/volunteer_link_display.tmpl" with sched_event=occurrence occurrence=occurrence.object icon_class="volunteer-icon" %}
      {% include "gbe/scheduling/evaluate_icon.tmpl" with evaluate=occurrence.evaluate %}
      {{ occurrence.object.start_time|date:"g:i A" }}-{{ occurrence.object.end_time|date:"g:i A" }}<br>
-     <b><a href="{{occurrence.detail_link}}" class="detail_link">{{ occurrence.object.title}}</a></b><br>
+     <b><a href="{{occurrence.detail_link}}" class="detail_link">{{ occurrence.title}}</a></b><br>
      {% for role, teacher in occurrence.teachers %}{{ role }}:  {{ teacher.name }}
      {% if not forloop.last %}, {% endif %}{% endfor %}<br>
      <i>{{ occurrence.object.location }}</i>

--- a/gbe/templates/gbe/scheduling/event_detail.tmpl
+++ b/gbe/templates/gbe/scheduling/event_detail.tmpl
@@ -28,7 +28,7 @@
 	<div class="row px-4">
 	  <div class="col-1 col-sm-2 col-md-3 col-lg-1 pt-3 pr-3">
       {% include "gbe/scheduling/favorite_star.tmpl" with size="fa-2x" disable_style="detail_link-detail_disable"%}
-      {% include "gbe/scheduling/volunteer_link_display.tmpl" with size="fa-2x" icon_class="volunteer-icon-large" disable_style="detail_link-detail_disable" %}
+      {% include "gbe/scheduling/volunteer_link_display.tmpl" with size="fa-2x" icon_class="volunteer-icon-large" disable_style="detail_link-detail_disable" occurrence=eventitem.occurrence %}
       {% include "gbe/scheduling/evaluate_icon.tmpl" with size="fa-2x" disable_style="detail_link-detail_disable" evaluate=sched_event.evaluate%}
 	  </div>
 	  <div class="col-11 col-sm-10 col-md-9 col-lg-4">

--- a/gbe/templates/gbe/scheduling/event_display_list.tmpl
+++ b/gbe/templates/gbe/scheduling/event_display_list.tmpl
@@ -76,7 +76,7 @@
 	  <label class="sched_detail">Time/Place:</label></div>
  	  <div class="col-xs-12 col-sm-10">
       {% include "gbe/scheduling/favorite_star.tmpl" with sched_event=event%}
-      {% include "gbe/scheduling/volunteer_link_display.tmpl" with icon_class="volunteer-icon" sched_event=event %}
+      {% include "gbe/scheduling/volunteer_link_display.tmpl" with icon_class="volunteer-icon" sched_event=event occurrence=event.occurrence %}
       {% include "gbe/scheduling/evaluate_icon.tmpl" with evaluate=event.evaluate %}
       {{ event.occurrence.start_time|date:_("DATETIME_FORMAT") }} -
 	    {{ event.occurrence.end_time|date:_("TIME_FORMAT") }} - {{ event.occurrence.location }}

--- a/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
+++ b/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
@@ -1,9 +1,35 @@
      {% if sched_event.volunteer_link and sched_event.volunteer_link != "disabled" %}
-      <a href="{{sched_event.volunteer_link}}?next={{ request.get_full_path }}"
-         class="detail_link cal-favorite" data-toggle="tooltip"
-         title="{%if sched_event.highlight == "volunteer" %}Remove from schedule{% elif sched_event.highlight == "pending volunteer" %}Retract pending offer{% else %}Volunteer for this opportunity!{% endif %}">
+      <a href="#" data-toggle="modal" data-target="#Modal{{eventitem.occurrence.pk}}" data-backdrop="true"
+         class="detail_link cal-favorite" title="{%if sched_event.highlight == "volunteer" %}Remove from schedule{% elif sched_event.highlight == "pending volunteer" %}Retract pending offer{% else %}Volunteer for this opportunity!{% endif %}">
        {% include "gbe/scheduling/volunteer_icon.tmpl" with occurrence=sched_event %}</a>
       </a>
+      <div class="modal" id="Modal{{eventitem.occurrence.pk}}" role="dialog">
+         <div class="modal-dialog modal-dialog-centered modal-md">
+            <div class="modal-content gbe-modal-content">
+               <form action="{{sched_event.volunteer_link}}?next={{ request.get_full_path }}" method="post" enctype="multipart/form-data">
+               <div class="modal-header gbe-modal-header">
+                  <h4 class="modal-title">Volunteer for {{eventitem.occurrence.title}}</h4>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+               </div>
+               <div class="modal-body">
+                  {% include "gbe/scheduling/volunteer_icon.tmpl" with icon_class="volunteer-icon-large" occurrence=sched_event %}
+                  <b>Time:</b> {{ eventitem.occurrence.start_time|date:_("DATETIME_FORMAT")}} - 
+        {{ eventitem.occurrence.end_time|date:_("TIME_FORMAT")}}<br>
+                  <b>Location:</b> {{ eventitem.occurrence.location }}<br>
+                  {% if sched_event.approval_needed %}<div class="well well-sm">
+                    {{ pending_note}}
+                  </div>{% endif %}
+                  {% if sched_event.complete_profile_form %}
+                  <div class="pt-4">{% include "form_table.tmpl" with form=sched_event.complete_profile_form %}</div>
+                  {% endif %}
+                </div>
+                <div class="modal-footer gbe-modal-footer">
+                    <input type="submit" value='{%if sched_event.highlight == "volunteer" %}Remove from schedule{% elif sched_event.highlight == "pending volunteer" %}Retract pending offer{% else %}Volunteer for this opportunity!{% endif %}' name="submit_done" class="btn gbe-btn-primary">
+                    <button type="button" class="btn gbe-btn-light" data-dismiss="modal">Close</button>
+                </div>
+                {% csrf_token %}
+                </form>
+              </div></div></div>
      {% elif sched_event.volunteer_link %}
       <a href="#" class="detail_link-disabled cal-favorite {{ disable_style }}" data-toggle="tooltip"
          title="{% if sched_event.vol_disable_msg %}{{sched_event.vol_disable_msg}}{% else %}You are a {{ sched_event.highlight }} - contact the coordinator to change your schedule{% endif %}">

--- a/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
+++ b/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
@@ -6,7 +6,6 @@
       <div class="modal" id="Modal{{occurrence.pk}}" role="dialog">
          <div class="modal-dialog modal-dialog-centered modal-md">
             <div class="modal-content gbe-modal-content">
-               <form action="{{sched_event.volunteer_link}}?next={{ request.get_full_path }}" method="post" enctype="multipart/form-data">
                <div class="modal-header gbe-modal-header">
                   <h4 class="modal-title">Volunteer for {{occurrence.title}}</h4>
                   <button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -19,6 +18,8 @@
                   {% if sched_event.approval_needed %}<div class="well well-sm">
                     {{ pending_note}}
                   </div>{% endif %}
+               {% if user.is_authenticated %}
+               <form action="{{sched_event.volunteer_link}}?next={{ request.get_full_path }}" method="post" enctype="multipart/form-data">{% csrf_token %}
                   {% if complete_profile_form %}
                   <div class="pt-4">{% include "form_table.tmpl" with form=complete_profile_form %}</div>
                   {% endif %}
@@ -27,8 +28,7 @@
                     <input type="submit" value='{%if sched_event.highlight == "volunteer" %}Remove from schedule{% elif sched_event.highlight == "pending volunteer" %}Retract pending offer{% else %}Volunteer for this opportunity!{% endif %}' name="submit_done" class="btn gbe-btn-primary">
                     <button type="button" class="btn gbe-btn-light" data-dismiss="modal">Close</button>
                 </div>
-                {% csrf_token %}
-                </form>
+                </form>{% else %}<br>{{ login_please }}<br><br><a href="{% url 'gbe:register' %}?next={{ request.get_full_path }}" class="btn gbe-btn-primary m-2">Set Up Account</a><a href="{% url 'login' %}?next={{ request.get_full_path }}" class="btn gbe-btn-primary m-2">Login</a></div>{% endif %}
               </div></div></div>
      {% elif sched_event.volunteer_link %}
       <a href="#" class="detail_link-disabled cal-favorite {{ disable_style }}" data-toggle="tooltip"

--- a/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
+++ b/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
@@ -28,7 +28,7 @@
                     <input type="submit" value='{%if sched_event.highlight == "volunteer" %}Remove from schedule{% elif sched_event.highlight == "pending volunteer" %}Retract pending offer{% else %}Volunteer for this opportunity!{% endif %}' name="submit_done" class="btn gbe-btn-primary">
                     <button type="button" class="btn gbe-btn-light" data-dismiss="modal">Close</button>
                 </div>
-                </form>{% else %}<br>{{ login_please }}<br><br><a href="{% url 'gbe:register' %}?next={{ request.get_full_path }}" class="btn gbe-btn-primary m-2">Set Up Account</a><a href="{% url 'login' %}?next={{ request.get_full_path }}" class="btn gbe-btn-primary m-2">Login</a></div>{% endif %}
+                </form>{% else %}<br>{{ login_please | safe }}<br><br><a href="{% url 'gbe:register' %}?next={{ request.get_full_path }}" class="btn gbe-btn-primary m-2">Set Up Account</a><a href="{% url 'login' %}?next={{ request.get_full_path }}" class="btn gbe-btn-primary m-2">Login</a></div>{% endif %}
               </div></div></div>
      {% elif sched_event.volunteer_link %}
       <a href="#" class="detail_link-disabled cal-favorite {{ disable_style }}" data-toggle="tooltip"

--- a/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
+++ b/gbe/templates/gbe/scheduling/volunteer_link_display.tmpl
@@ -1,26 +1,26 @@
      {% if sched_event.volunteer_link and sched_event.volunteer_link != "disabled" %}
-      <a href="#" data-toggle="modal" data-target="#Modal{{eventitem.occurrence.pk}}" data-backdrop="true"
+      <a href="#" data-toggle="modal" data-target="#Modal{{occurrence.pk}}" data-backdrop="true"
          class="detail_link cal-favorite" title="{%if sched_event.highlight == "volunteer" %}Remove from schedule{% elif sched_event.highlight == "pending volunteer" %}Retract pending offer{% else %}Volunteer for this opportunity!{% endif %}">
        {% include "gbe/scheduling/volunteer_icon.tmpl" with occurrence=sched_event %}</a>
       </a>
-      <div class="modal" id="Modal{{eventitem.occurrence.pk}}" role="dialog">
+      <div class="modal" id="Modal{{occurrence.pk}}" role="dialog">
          <div class="modal-dialog modal-dialog-centered modal-md">
             <div class="modal-content gbe-modal-content">
                <form action="{{sched_event.volunteer_link}}?next={{ request.get_full_path }}" method="post" enctype="multipart/form-data">
                <div class="modal-header gbe-modal-header">
-                  <h4 class="modal-title">Volunteer for {{eventitem.occurrence.title}}</h4>
+                  <h4 class="modal-title">Volunteer for {{occurrence.title}}</h4>
                   <button type="button" class="close" data-dismiss="modal">&times;</button>
                </div>
                <div class="modal-body">
                   {% include "gbe/scheduling/volunteer_icon.tmpl" with icon_class="volunteer-icon-large" occurrence=sched_event %}
-                  <b>Time:</b> {{ eventitem.occurrence.start_time|date:_("DATETIME_FORMAT")}} - 
-        {{ eventitem.occurrence.end_time|date:_("TIME_FORMAT")}}<br>
-                  <b>Location:</b> {{ eventitem.occurrence.location }}<br>
+                  <b>Time:</b> {{ occurrence.start_time|date:"M j, Y, g:i A"}} - 
+        {{ occurrence.end_time|date:"g:i A"}}<br>
+                  <b>Location:</b> {{ occurrence.location }}<br>
                   {% if sched_event.approval_needed %}<div class="well well-sm">
                     {{ pending_note}}
                   </div>{% endif %}
-                  {% if sched_event.complete_profile_form %}
-                  <div class="pt-4">{% include "form_table.tmpl" with form=sched_event.complete_profile_form %}</div>
+                  {% if complete_profile_form %}
+                  <div class="pt-4">{% include "form_table.tmpl" with form=complete_profile_form %}</div>
                   {% endif %}
                 </div>
                 <div class="modal-footer gbe-modal-footer">

--- a/gbetext.py
+++ b/gbetext.py
@@ -685,6 +685,8 @@ with a highlighted box require approval, when you volunteer, your offer will \
 be reviewed and a response will be sent shortly.'''
 pending_note = '''This is a shift that requires approval.  When you volunteer,\
  your offer will be reviewed and a response will be sent shortly.'''
+login_please = '''To volunteer, you must have an account with the expo.  \
+Set up an account or login and we'll bring you back here to volunteer.'''
 interested_explain_msg = '''Anyone with an account with The Great Burlesque \
 Exposition can show their interest in an event and add it to their schedule \
 by clicking on the star on our calendar or in an event description.  Starred \

--- a/tests/gbe/scheduling/test_calendar_view.py
+++ b/tests/gbe/scheduling/test_calendar_view.py
@@ -490,7 +490,6 @@ class TestCalendarView(TestCase):
         volunteer, booking = self.staffcontext.book_volunteer()
         opportunity = booking.event
         opportunity.starttime = datetime.now() + timedelta(days=1)
-        opportunity.max_volunteers = 1
         opportunity.save()
         ConferenceDayFactory(conference=self.staffcontext.conference,
                              day=opportunity.starttime)
@@ -503,6 +502,22 @@ class TestCalendarView(TestCase):
         self.assertContains(
           response,
           'This event has all the volunteers it needs.')
+
+    def test_volunteer_event_no_login(self):
+        volunteer, booking = self.staffcontext.book_volunteer()
+        opportunity = booking.event
+        opportunity.starttime = datetime.now() + timedelta(days=1)
+        opportunity.max_volunteer = 10
+        opportunity.save()
+        ConferenceDayFactory(conference=self.staffcontext.conference,
+                             day=opportunity.starttime)
+        url = reverse('calendar',
+                      urlconf="gbe.scheduling.urls",
+                      args=['Volunteer'])
+        response = self.client.get(url, data={
+            'day': opportunity.starttime.strftime('%m-%d-%Y')}, follow=True)
+        self.assertContains(response, opportunity.title)
+        self.assertContains(response, login_please)
 
     def test_disabled_eval(self):
         eval_profile = self.classcontext.set_eval_answerer()

--- a/tests/gbe/scheduling/test_calendar_view.py
+++ b/tests/gbe/scheduling/test_calendar_view.py
@@ -125,6 +125,13 @@ class TestCalendarView(TestCase):
         self.assertNotContains(response, self.other_show.sched_event.title)
         self.assertNotContains(response, self.classcontext.bid.b_title)
         self.assertContains(response, self.volunteeropp.title)
+        self.assertNotContains(
+            response,
+            reverse('set_volunteer',
+                    args=[self.volunteeropp.pk, 'on'],
+                    urlconf='gbe.scheduling.urls'))
+        self.assertContains(response, reverse('login'))
+        self.assertContains(response, reverse('register', urlconf="gbe.urls"))
 
     def test_calendar_conference_w_default_conf_public_days(self):
         conference_day = ConferenceDayFactory(
@@ -469,6 +476,9 @@ class TestCalendarView(TestCase):
         opportunity = booking.event
         opportunity.starttime = datetime.now() + timedelta(days=1)
         opportunity.save()
+        vol_link = reverse('set_volunteer',
+                           args=[opportunity.pk, 'off'],
+                           urlconf='gbe.scheduling.urls')
         ConferenceDayFactory(conference=self.staffcontext.conference,
                              day=opportunity.starttime)
         login_as(volunteer, self)
@@ -480,6 +490,7 @@ class TestCalendarView(TestCase):
         self.assertContains(response, opportunity.title)
         self.assertContains(response,
                             'class="volunteer-icon" alt="You\'ve signed up"/>')
+        self.assertContains(response, vol_link)
 
     def test_volunteer_event_full(self):
         volunteer, booking = self.staffcontext.book_volunteer()

--- a/tests/gbe/scheduling/test_calendar_view.py
+++ b/tests/gbe/scheduling/test_calendar_view.py
@@ -27,6 +27,7 @@ from tests.contexts import (
     StaffAreaContext,
 )
 from gbe.models import ConferenceDay
+from gbetext import login_please
 
 
 class TestCalendarView(TestCase):
@@ -125,13 +126,6 @@ class TestCalendarView(TestCase):
         self.assertNotContains(response, self.other_show.sched_event.title)
         self.assertNotContains(response, self.classcontext.bid.b_title)
         self.assertContains(response, self.volunteeropp.title)
-        self.assertNotContains(
-            response,
-            reverse('set_volunteer',
-                    args=[self.volunteeropp.pk, 'on'],
-                    urlconf='gbe.scheduling.urls'))
-        self.assertContains(response, reverse('login'))
-        self.assertContains(response, reverse('register', urlconf="gbe.urls"))
 
     def test_calendar_conference_w_default_conf_public_days(self):
         conference_day = ConferenceDayFactory(

--- a/tests/gbe/scheduling/test_event_detail_view.py
+++ b/tests/gbe/scheduling/test_event_detail_view.py
@@ -34,6 +34,10 @@ from datetime import (
     datetime,
     timedelta,
 )
+from gbetext import (
+    login_please,
+    pending_note,
+)
 
 
 class TestEventDetailView(TestCase):
@@ -309,6 +313,7 @@ class TestEventDetailView(TestCase):
         self.assertContains(response, opportunity.title)
         self.assertContains(response, vol_link)
         self.assertContains(response, 'awaiting_approval.gif')
+        self.assertContains(response, pending_note)
 
     def test_view_volunteers(self):
         staff_context = StaffAreaContext()
@@ -319,6 +324,7 @@ class TestEventDetailView(TestCase):
                       urlconf="gbe.scheduling.urls",
                       args=[opportunity.pk])
         response = self.client.get(url)
+        print(response.content)
         self.assertContains(response, opportunity.title)
         self.assertContains(response,
                             'volunteered.gif" class="volunteer-icon-large"')
@@ -329,3 +335,4 @@ class TestEventDetailView(TestCase):
                     urlconf='gbe.scheduling.urls'))
         self.assertContains(response, reverse('login'))
         self.assertContains(response, reverse('register', urlconf="gbe.urls"))
+        self.assertContains(response, login_please)

--- a/tests/gbe/scheduling/test_event_detail_view.py
+++ b/tests/gbe/scheduling/test_event_detail_view.py
@@ -319,10 +319,13 @@ class TestEventDetailView(TestCase):
                       urlconf="gbe.scheduling.urls",
                       args=[opportunity.pk])
         response = self.client.get(url)
-        vol_link = reverse('set_volunteer',
-                           args=[opportunity.pk, 'on'],
-                           urlconf='gbe.scheduling.urls')
         self.assertContains(response, opportunity.title)
-        self.assertContains(response, vol_link)
         self.assertContains(response,
                             'volunteered.gif" class="volunteer-icon-large"')
+        self.assertNotContains(
+            response,
+            reverse('set_volunteer',
+                    args=[opportunity.pk, 'on'],
+                    urlconf='gbe.scheduling.urls'))
+        self.assertContains(response, reverse('login'))
+        self.assertContains(response, reverse('register', urlconf="gbe.urls"))

--- a/tests/gbe/scheduling/test_event_detail_view.py
+++ b/tests/gbe/scheduling/test_event_detail_view.py
@@ -331,7 +331,6 @@ class TestEventDetailView(TestCase):
                       urlconf="gbe.scheduling.urls",
                       args=[opportunity.pk])
         response = self.client.get(url)
-        print(response.content)
         self.assertContains(response, opportunity.title)
         self.assertContains(response,
                             'volunteered.gif" class="volunteer-icon-large"')

--- a/tests/gbe/scheduling/test_list_events.py
+++ b/tests/gbe/scheduling/test_list_events.py
@@ -23,6 +23,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+from gbetext import pending_note
 
 
 class TestViewList(TestCase):
@@ -267,6 +268,7 @@ class TestViewList(TestCase):
         self.assertContains(response, opportunity.title)
         self.assertContains(response, vol_link)
         self.assertContains(response, 'awaiting_approval.gif')
+        self.assertContains(response, pending_note)
 
     def test_view_volunteers_rejected(self):
         context = StaffAreaContext(conference=self.conf)

--- a/tests/gbe/scheduling/test_list_events.py
+++ b/tests/gbe/scheduling/test_list_events.py
@@ -216,7 +216,6 @@ class TestViewList(TestCase):
         volunteer, booking = staff_context.book_volunteer()
         opportunity = booking.event
         opportunity.starttime = datetime.now() + timedelta(days=1)
-        opportunity.max_volunteers = 1
         opportunity.save()
         url = reverse("event_list",
                       urlconf="gbe.scheduling.urls",

--- a/tests/gbe/scheduling/test_list_events.py
+++ b/tests/gbe/scheduling/test_list_events.py
@@ -207,6 +207,8 @@ class TestViewList(TestCase):
         self.assertNotContains(response, this_class.b_title)
         self.assertNotContains(response, 'fa-star')
         self.assertNotContains(response, 'fa-star-o')
+        self.assertNotContains(response,
+                               reverse('register', urlconf="gbe.urls"))
 
     def test_view_volunteer_filled(self):
         staff_context = StaffAreaContext(conference=self.conf)


### PR DESCRIPTION
When we refactored for requiring a minimal profile w. first/last/phone for volunteers, I broke the event view side of things, namely:
- list events
- event detail page
- calendar view

Where a volunteer could check a check box and sign up for something.

I managed to preserve that feature by:
- requiring that not-logged-in users using these pages login first and get redirected (automatically) to the page
- adding the form for first/last/phone to the pages above, if it's not already in the user's profile & the user is logged in
- submitting through set_volunteers with no change to that process

Since the code shared a volunteer link logic blob as a template, it was somewhat easy to refactor that into a modal similar to the volunteer signup page.  They can't share code - the layout differences are enough to have two different modals.

There's also some rough edges around how views send data to templates - it would be nice if this area is designed more consistently.  But that seemed to be live with able tech debt.

LOC - all but 74 lines
pepdiff - all set
Added new test conditions but not new tests