### PR TITLE
Gbe 397: New UX for Event Management filter

### DIFF
--- a/gbe/scheduling/forms/__init__.py
+++ b/gbe/scheduling/forms/__init__.py
@@ -24,10 +24,7 @@ from .generic_booking_form import GenericBookingForm
 from .person_allocation_form import PersonAllocationForm
 from .rehearsal_slot_form import RehearsalSlotForm
 
-from .select_event_form import (
-    HiddenSelectEventForm,
-    SelectEventForm,
-)
+from .select_event_form import SelectEventForm
 from .event_evaluation_form import EventEvaluationForm
 from .act_schedule_form import ActScheduleBasics
 from .conference_start_change_form import ConferenceStartChangeForm

--- a/gbe/scheduling/forms/select_event_form.py
+++ b/gbe/scheduling/forms/select_event_form.py
@@ -6,7 +6,7 @@ from django.forms import (
 )
 from django.forms.widgets import CheckboxSelectMultiple
 from gbetext import calendar_type as calendar_type_options
-from gbe_forms_text import flat_event_type_only
+from gbe_forms_text import event_styles_complete
 from gbe.models import StaffArea
 from django.db.models.functions import Lower
 
@@ -22,7 +22,7 @@ class SelectEventForm(Form):
         widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
         required=False)
     event_style = MultipleChoiceField(
-        choices=flat_event_type_only,
+        choices=event_styles_complete,
         widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
         required=False)
     staff_area = ModelMultipleChoiceField(

--- a/gbe/scheduling/forms/select_event_form.py
+++ b/gbe/scheduling/forms/select_event_form.py
@@ -6,6 +6,7 @@ from django.forms import (
 )
 from django.forms.widgets import CheckboxSelectMultiple
 from gbetext import calendar_type as calendar_type_options
+from gbe_forms_text import event_type_options
 from gbe.models import StaffArea
 from django.db.models.functions import Lower
 
@@ -18,6 +19,10 @@ class SelectEventForm(Form):
         required=False)
     calendar_type = MultipleChoiceField(
         choices=list(calendar_type_options.items()),
+        widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
+        required=False)
+    event_style = MultipleChoiceField(
+        choices=list(event_type_options),
         widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
         required=False)
     staff_area = ModelMultipleChoiceField(
@@ -34,6 +39,10 @@ class HiddenSelectEventForm(Form):
         required=False)
     calendar_type = MultipleChoiceField(
         choices=list(calendar_type_options.items()),
+        widget=MultipleHiddenInput(),
+        required=False)
+    event_style = MultipleChoiceField(
+        choices=list(event_type_options),
         widget=MultipleHiddenInput(),
         required=False)
     staff_area = ModelMultipleChoiceField(

--- a/gbe/scheduling/forms/select_event_form.py
+++ b/gbe/scheduling/forms/select_event_form.py
@@ -29,23 +29,3 @@ class SelectEventForm(Form):
         queryset=StaffArea.objects.all().order_by("conference", "slug"),
         widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
         required=False)
-
-
-class HiddenSelectEventForm(Form):
-    required_css_class = 'required'
-    error_css_class = 'error'
-    day = MultipleChoiceField(
-        widget=MultipleHiddenInput(),
-        required=False)
-    calendar_type = MultipleChoiceField(
-        choices=list(calendar_type_options.items()),
-        widget=MultipleHiddenInput(),
-        required=False)
-    event_style = MultipleChoiceField(
-        choices=flat_event_type_only,
-        widget=MultipleHiddenInput(),
-        required=False)
-    staff_area = ModelMultipleChoiceField(
-        queryset=StaffArea.objects.all().order_by("conference", "slug"),
-        widget=MultipleHiddenInput(),
-        required=False)

--- a/gbe/scheduling/forms/select_event_form.py
+++ b/gbe/scheduling/forms/select_event_form.py
@@ -6,7 +6,7 @@ from django.forms import (
 )
 from django.forms.widgets import CheckboxSelectMultiple
 from gbetext import calendar_type as calendar_type_options
-from gbe_forms_text import event_type_options
+from gbe_forms_text import flat_event_type_only
 from gbe.models import StaffArea
 from django.db.models.functions import Lower
 
@@ -22,7 +22,7 @@ class SelectEventForm(Form):
         widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
         required=False)
     event_style = MultipleChoiceField(
-        choices=list(event_type_options),
+        choices=flat_event_type_only,
         widget=CheckboxSelectMultiple(attrs={'class': 'form-check-input'}),
         required=False)
     staff_area = ModelMultipleChoiceField(
@@ -42,7 +42,7 @@ class HiddenSelectEventForm(Form):
         widget=MultipleHiddenInput(),
         required=False)
     event_style = MultipleChoiceField(
-        choices=list(event_type_options),
+        choices=flat_event_type_only,
         widget=MultipleHiddenInput(),
         required=False)
     staff_area = ModelMultipleChoiceField(

--- a/gbe/scheduling/views/manage_events_view.py
+++ b/gbe/scheduling/views/manage_events_view.py
@@ -41,7 +41,6 @@ class ManageEventsView(View):
 
     def groundwork(self, request, args, kwargs):
         validate_perms(request, ('Scheduling Mavens', 'Admins'))
-        context = {}
         self.conference = None
         conference_set = conference_list().order_by('-conference_slug')
 
@@ -66,6 +65,7 @@ class ManageEventsView(View):
                 conf.conference_slug for conf in conference_set],
             'selection_form': select_form,
             'other_forms': [],
+            'view_title': "Events",
         }
         if 'new' in list(request.GET.keys()):
             context['success_occurrences'] = eval(request.GET['new'])

--- a/gbe/scheduling/views/manage_events_view.py
+++ b/gbe/scheduling/views/manage_events_view.py
@@ -141,7 +141,7 @@ class ManageEventsView(View):
                     '<b>%s</b>' % ', '.join(cal_types))
             if len(select_form.cleaned_data['event_style']) > 0:
                 for event_style in select_form.cleaned_data['event_style']:
-                    event_styles += [string.capwords(event_style)]
+                    event_styles += [event_style]
                 select_form.fields['event_style'].label = (
                     '<b>%s</b>' % ', '.join(event_styles))
             if len(select_form.cleaned_data['staff_area']) > 0:

--- a/gbe/scheduling/views/manage_events_view.py
+++ b/gbe/scheduling/views/manage_events_view.py
@@ -152,25 +152,38 @@ class ManageEventsView(View):
                 for cal_type in select_form.cleaned_data['calendar_type']:
                     cal_types += [calendar_type[int(cal_type)]]
                 label_set += [cal_types]
+                select_form.fields['calendar_type'].label = (
+                    '<b>%s</b>' % ', '.join(cal_types))
             if len(select_form.cleaned_data['event_style']) > 0:
                 for event_style in select_form.cleaned_data['event_style']:
                     event_styles += [string.capwords(event_style)]
+                select_form.fields['event_style'].label = (
+                    '<b>%s</b>' % ', '.join(event_styles))
             if len(select_form.cleaned_data['staff_area']) > 0:
                 staff_areas = []
+                staff_area_labels = []
+
                 for staff_area in select_form.cleaned_data['staff_area']:
                     staff_areas += [staff_area.slug]
+                    staff_area_labels += [staff_area.title]
                 label_set += [staff_areas]
+                select_form.fields['staff_area'].label = (
+                    '<b>%s</b>' % ', '.join(staff_area_labels))
             if len(select_form.cleaned_data['day']) > 0:
+                days = []
                 for day_id in select_form.cleaned_data['day']:
                     day = ConferenceDay.objects.get(pk=day_id)
                     response = get_occurrences(label_sets=label_set,
                                                event_styles=event_styles,
                                                day=day.day)
+                    days += [str(day)]
+                    occurrences += response.occurrences
+                select_form.fields['day'].label = '<b>%s</b>' % ', '.join(days)
+
         if day is None:
             response = get_occurrences(label_sets=label_set,
                                        event_styles=event_styles)
-
-        occurrences += response.occurrences
+            occurrences += response.occurrences
         return self.build_occurrence_display(occurrences)
 
     @never_cache

--- a/gbe/scheduling/views/manage_events_view.py
+++ b/gbe/scheduling/views/manage_events_view.py
@@ -25,10 +25,7 @@ from gbe.functions import (
     validate_perms,
 )
 from scheduler.idd import get_occurrences
-from gbe.scheduling.forms import (
-    HiddenSelectEventForm,
-    SelectEventForm,
-)
+from gbe.scheduling.forms import SelectEventForm
 from gbetext import (
     calendar_for_event,
     calendar_type,
@@ -65,24 +62,12 @@ class ManageEventsView(View):
             'conference_slugs': [
                 conf.conference_slug for conf in conference_set],
             'selection_form': select_form,
-            'other_forms': [],
             'view_title': "Events",
         }
         if 'new' in list(request.GET.keys()):
             context['success_occurrences'] = eval(request.GET['new'])
         if 'alt_id' in list(request.GET.keys()):
             context['alt_id'] = int(request.GET['alt_id'])
-        for conf in conference_set:
-            if self.conference != conf:
-                hidden_form = HiddenSelectEventForm(
-                    request.GET,
-                    prefix=conf.conference_slug)
-                conf_day_list = []
-                for day in conf.conferenceday_set.all():
-                    conf_day_list += [(day.pk,
-                                       day.day.strftime(GBE_DATE_FORMAT))]
-                hidden_form.fields['day'].choices = conf_day_list
-                context['other_forms'] += [hidden_form]
         return context
 
     def build_occurrence_display(self, occurrences):

--- a/gbe/scheduling/views/manage_events_view.py
+++ b/gbe/scheduling/views/manage_events_view.py
@@ -33,6 +33,7 @@ from gbetext import (
     calendar_for_event,
     calendar_type,
 )
+import string
 
 
 class ManageEventsView(View):
@@ -142,6 +143,7 @@ class ManageEventsView(View):
     def get_filtered_occurrences(self, request, select_form):
         occurrences = []
         label_set = [[self.conference.conference_slug]]
+        event_styles = []
         day = None
 
         if select_form.is_valid():
@@ -150,6 +152,9 @@ class ManageEventsView(View):
                 for cal_type in select_form.cleaned_data['calendar_type']:
                     cal_types += [calendar_type[int(cal_type)]]
                 label_set += [cal_types]
+            if len(select_form.cleaned_data['event_style']) > 0:
+                for event_style in select_form.cleaned_data['event_style']:
+                    event_styles += [string.capwords(event_style)]
             if len(select_form.cleaned_data['staff_area']) > 0:
                 staff_areas = []
                 for staff_area in select_form.cleaned_data['staff_area']:
@@ -159,9 +164,11 @@ class ManageEventsView(View):
                 for day_id in select_form.cleaned_data['day']:
                     day = ConferenceDay.objects.get(pk=day_id)
                     response = get_occurrences(label_sets=label_set,
+                                               event_styles=event_styles,
                                                day=day.day)
         if day is None:
-            response = get_occurrences(label_sets=label_set)
+            response = get_occurrences(label_sets=label_set,
+                                       event_styles=event_styles)
 
         occurrences += response.occurrences
         return self.build_occurrence_display(occurrences)

--- a/gbe/scheduling/views/manage_events_view.py
+++ b/gbe/scheduling/views/manage_events_view.py
@@ -142,28 +142,28 @@ class ManageEventsView(View):
     def get_filtered_occurrences(self, request, select_form):
         occurrences = []
         label_set = [[self.conference.conference_slug]]
+        day = None
 
-        if len(select_form.cleaned_data['calendar_type']) > 0:
-            cal_types = []
-            for cal_type in select_form.cleaned_data['calendar_type']:
-                cal_types += [calendar_type[int(cal_type)]]
-            label_set += [cal_types]
-        if len(select_form.cleaned_data['staff_area']) > 0:
-            staff_areas = []
-            for staff_area in select_form.cleaned_data['staff_area']:
-                staff_areas += [staff_area.slug]
-            label_set += [staff_areas]
-        if len(select_form.cleaned_data['day']) > 0:
-            for day_id in select_form.cleaned_data['day']:
-                day = ConferenceDay.objects.get(pk=day_id)
-                response = get_occurrences(label_sets=label_set,
-                                           day=day.day)
-                occurrences += response.occurrences
-        else:
-            response = get_occurrences(
-                label_sets=label_set)
-            occurrences += response.occurrences
+        if select_form.is_valid():
+            if len(select_form.cleaned_data['calendar_type']) > 0:
+                cal_types = []
+                for cal_type in select_form.cleaned_data['calendar_type']:
+                    cal_types += [calendar_type[int(cal_type)]]
+                label_set += [cal_types]
+            if len(select_form.cleaned_data['staff_area']) > 0:
+                staff_areas = []
+                for staff_area in select_form.cleaned_data['staff_area']:
+                    staff_areas += [staff_area.slug]
+                label_set += [staff_areas]
+            if len(select_form.cleaned_data['day']) > 0:
+                for day_id in select_form.cleaned_data['day']:
+                    day = ConferenceDay.objects.get(pk=day_id)
+                    response = get_occurrences(label_sets=label_set,
+                                               day=day.day)
+        if day is None:
+            response = get_occurrences(label_sets=label_set)
 
+        occurrences += response.occurrences
         return self.build_occurrence_display(occurrences)
 
     @never_cache
@@ -171,26 +171,21 @@ class ManageEventsView(View):
     def get(self, request, *args, **kwargs):
         context = self.groundwork(request, args, kwargs)
 
-        if context['selection_form'].is_valid() and (
-                len(context['selection_form'].cleaned_data['day']) > 0 or len(
-                    context['selection_form'].cleaned_data[
-                        'calendar_type']) > 0 or len(
-                    context['selection_form'].cleaned_data['staff_area']) > 0):
-            context['occurrences'] = self.get_filtered_occurrences(
-                request,
-                context['selection_form'])
-            context['columns'] = [
-                'Title',
-                'Parent',
-                'Area',
-                'Location',
-                'Date/Time',
-                'Duration',
-                'Type',
-                'Current #',
-                'Max #',
-                'Action']
-            context['order'] = 4
+        context['occurrences'] = self.get_filtered_occurrences(
+            request,
+            context['selection_form'])
+        context['columns'] = [
+            'Title',
+            'Parent',
+            'Area',
+            'Location',
+            'Date/Time',
+            'Duration',
+            'Type',
+            'Current #',
+            'Max #',
+            'Action']
+        context['order'] = 4
         return render(request, self.template, context)
 
     @method_decorator(login_required)

--- a/gbe/templates/gbe/gbe_table.tmpl
+++ b/gbe/templates/gbe/gbe_table.tmpl
@@ -116,6 +116,8 @@
         // Toggle the visibility
         column.visible( ! column.visible() );
     } );
+{% block on_ready_js %}
+{% endblock %}
   } );
   </script>
   <script>jQuery(function($){

--- a/gbe/templates/gbe/gbe_table.tmpl
+++ b/gbe/templates/gbe/gbe_table.tmpl
@@ -32,8 +32,11 @@
     {% endfor %} 
   </form></div></div>
   {% endif %}
-  <div>
-    <b>Toggle column(s):</b>
+  <div class="text-right">
+  <a class="btn btn-light" data-toggle="collapse" data-text-alt="Hide Toggle Columns" href="#toggleToggle" role="button" aria-expanded="false" aria-controls="toggleToggle">
+    Show Toggle Columns
+  </a></div>
+  <div class="collapse text-right mt-3" id="toggleToggle">
     {% for column in columns %}
     <button type="button" class="btn btn-sm gbe-btn-secondary toggle-vis" data-toggle="button" aria-pressed="false" autocomplete="off" data-column="{{ forloop.counter0 }}">{{column}}</button>
     {% endfor %}
@@ -115,5 +118,12 @@
     } );
   } );
   </script>
+  <script>jQuery(function($){
+  $('.btn[data-toggle="collapse"]').on('click', function(){
+    $(this)
+    .data('text-original', $(this).text())
+    .text($(this).data('text-alt') )
+    .data('text-alt', $(this).data('text-original'));
+  });});</script>
 {% endaddtoblock %}
 {% endblock %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -7,13 +7,19 @@
  {% for form in other_forms %}
   {{ form }}
  {% endfor %}
-<div class="container review">
- <ul class="nav nav-tabs" id="inner">
+<div class="container review"><div class="row">
+  <div class="col-md-8">
+    <h2 class="gbe-title">{{view_title}}{% if conference.status != "completed" %}
+      <a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn btn-secondary">Create</a>{% endif %}</h2>
+   </div><div class="col-md-4 text-right">
+  <div class="dropdown show">
+    <a class="btn gbe-btn-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
  {% for slug in conference_slugs %}
-  <li role="presentation"><a href="{% url 'scheduling:manage_event_list' slug %}?{{ request.GET.urlencode }}" class="{% if conference.conference_slug == slug %}gbe-tab-active{% else %}gbe-tab{% endif %}">{{slug}}</a></li>
+        <a class="dropdown-item" href="{% url 'scheduling:manage_event_list' slug %}?{{ request.GET.urlencode }}">{{slug}}</a>
  {% endfor %}
- </ul>
- <div class="gbe-tab-area">
+    </div></div></div></div>
+ <div class="gbe-tab-area my-2">
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.day %}
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
    <div class="form-row">
@@ -52,9 +58,7 @@
    <div class="form-row">
    <div class="form-group col-12 mb-2" id="filter-button"><br>
       <input type="submit" class="btn gbe-btn-primary" name="filter" value="Filter">
-   {% if conference.status != "completed" %}
-      &nbsp;<a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn gbe-btn-primary">Create</a>
-   {% endif %}</div></div>
+   </div></div>
    Yellow = volunteers must be approved.
    <div class="row"><div class="col-12">&nbsp;</div></div>
 {% endblock %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -3,7 +3,7 @@
   Manage Expo Schedule
 {% endblock %}
 {% block before_table %}
-<form action="" method="get" enctype="multipart/form-data">
+<form action="?" method="get" enctype="multipart/form-data">
 <div class="container review"><div class="row">
   <div class="col-md-8">
     <h2 class="gbe-title">{{view_title}}{% if conference.status != "completed" %}
@@ -26,7 +26,7 @@
     <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink">
      {% for checkbox in selection_form.staff_area %}
       <div class="dropdown-item">
-      <label class="checkbox-label gbe-filter mb-0" id="{{ checkbox.id_for_label }}">
+      <label class="checkbox-label gbe-filter mb-0">
       {{ checkbox.tag }}
       {{ checkbox.choice_label }}
       {% if conference.status != "completed" %}
@@ -52,9 +52,7 @@
   <div class="col col-md-auto mt-1 py-2" id="filter-box">
   </div>
   </div></div>
-   
-   Yellow = volunteers for this event must be approved.
-   <div class="row"><div class="col-12">&nbsp;</div></div>
+   <div class="row"><div class="col-12">Yellow = volunteers for this event must be approved.</div></div>
 {% endblock %}
 {% block tbody %}
     {% for occurrence in occurrences %}
@@ -88,7 +86,6 @@
     {% endfor %}
 {% endblock %}
 {% block after_table %}
- </div>
 </div>
 </form>
 {% endblock %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -10,7 +10,7 @@
 <div class="container review"><div class="row">
   <div class="col-md-8">
     <h2 class="gbe-title">{{view_title}}{% if conference.status != "completed" %}
-      <a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn btn-secondary">Create</a>{% endif %}</h2>
+      <a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn btn-secondary">+ Create New Event</a>{% endif %}</h2>
    </div><div class="col-md-4 text-right">
   <div class="dropdown show">
     <a class="btn gbe-btn-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
@@ -26,7 +26,7 @@
    <div class="dropdown">
     <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
      {{ selection_form.staff_area.label }}</button>
-   <div class="dropdown-menu" aria-labelledby="staffMenuLink"><div class="form-group">
+   <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink"><div class="form-group">
      {% for checkbox in selection_form.staff_area %}
       <div class="form-check-inline">
       <label class="checkbox-label gbe-filter" id="{{ checkbox.id_for_label }}">
@@ -42,15 +42,14 @@
       </a>
       </label></div>
      {% endfor %}
+     <input type="submit" class="btn btn-secondary w-100 mt-2" name="filter" value="Apply">
+   </div>
       {% if selection_form.staff_area.errors %}
         <font class="gbe-form-error">{{ selection_form.staff_area.errors }}</font>
       {% endif %}
-   </div></div></div>
-   <div class="form-group" id="filter-button">
-      <input type="submit" class="btn gbe-btn-primary" name="filter" value="Filter">
-   </div></div></div>
+    </div></div></div></div>
    
-   Yellow = volunteers must be approved.
+   Yellow = volunteers for this event must be approved.
    <div class="row"><div class="col-12">&nbsp;</div></div>
 {% endblock %}
 {% block tbody %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -11,7 +11,7 @@
    </div></div>
 <div class="row">
   <div class="gbe-tab-area my-2 col-auto mr-2"><div class="dropdown pt-2">
-    <a class="btn btn-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
+    <a class="btn btn-light btn-sm dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
   {% for slug in conference_slugs %}
         <a class="dropdown-item" href="{% url 'scheduling:manage_event_list' slug %}?{{ request.GET.urlencode }}">{{slug}}</a>
@@ -20,8 +20,8 @@
   <div class="gbe-tab-area my-2 col"><div class="btn-group row">
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.day %}
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.event_style %}
-   <div class="dropdown col col-md-auto">
-    <button class="btn btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+   <div class="dropdown col col-md-auto px-2">
+    <button class="btn btn-light btn-sm dropdown-toggle mt-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
      {{ selection_form.staff_area.label | safe }}</button>
     <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink">
      {% for checkbox in selection_form.staff_area %}
@@ -46,10 +46,10 @@
       {% endif %}
   </div>
     {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
-  <div class="col col-md-auto">
-     <a href="{% url 'scheduling:manage_event_list' conference.conference_slug %}" class="btn gbe-btn-primary mt-1">Clear All Filters</a>
+  <div class="col col-md-auto px-2">
+     <a href="{% url 'scheduling:manage_event_list' conference.conference_slug %}" class="btn btn-sm gbe-btn-primary mt-1">Clear All Filters</a>
   </div>
-  <div class="col col-md-auto mt-1 py-2" id="filter-box">
+  <div class="col col-md-auto mt-1 pt-1" id="filter-box">
   </div>
   </div></div></div>
   <div class="row"><div class="col-12">Yellow = volunteers for this event must be approved.</div></div>

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -25,7 +25,7 @@
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.event_style %}
    <div class="dropdown col col-md-auto">
     <button class="btn btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-     {{ selection_form.staff_area.label }}</button>
+     {{ selection_form.staff_area.label | safe }}</button>
     <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink">
      {% for checkbox in selection_form.staff_area %}
       <div class="dropdown-item">

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -20,45 +20,36 @@
  {% endfor %}
     </div></div></div></div>
  <div class="gbe-tab-area my-2">
+  <div class="btn-group">
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.day %}
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
-   <div class="form-row">
-   <div class="form-group col-md-2 col-12">
-    <label class="form-check-label horizontal-label" id="{{ selection_form.staff_area.name }}"><b>
-     {% if selection_form.staff_area.errors %}
-      <font class="gbe-form-error">!&nbsp;&nbsp;
-     {% endif %}
-     {{ selection_form.staff_area.label }}:&nbsp;&nbsp;
-     {% if selection_form.staff_area.errors %}
-      </font>
-     {% endif %}</b></label>
-   </div>
-   <div class="form-group col-md-10 col-12">
+   <div class="dropdown">
+    <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+     {{ selection_form.staff_area.label }}</button>
+   <div class="dropdown-menu" aria-labelledby="staffMenuLink"><div class="form-group">
      {% for checkbox in selection_form.staff_area %}
-      <div class="form-group col-md-4 col-sm-4 col-12 checkbox-box{%if alt_id|slugify == checkbox.data.value|slugify %} checkbox-box-success{%endif%}">
       <div class="form-check-inline">
-      <label class="form-check-label staff-checkbox-label" id="{{ checkbox.id_for_label }}">
+      <label class="checkbox-label gbe-filter" id="{{ checkbox.id_for_label }}">
       {{ checkbox.tag }}
-      {{ checkbox.choice_label }}&nbsp;
+      {{ checkbox.choice_label }}
       {% if conference.status != "completed" %}
-      &nbsp;<a href="{% url "scheduling:edit_staff" checkbox.data.value %}" data-toggle="tooltip" title="Edit" class="detail_link">
+      <a href="{% url "scheduling:edit_staff" checkbox.data.value %}" data-toggle="tooltip" title="Edit" class="detail_link ml-1">
        <i class="fa fa-pencil-square" aria-hidden="true"></i>
       </a>
      {% endif %}
-      &nbsp;<a href="{% url "scheduling:copy_staff_schedule" checkbox.data.value %}" data-toggle="tooltip" title="Copy" class="detail_link">
+      &nbsp;<a href="{% url "scheduling:copy_staff_schedule" checkbox.data.value %}" data-toggle="tooltip" title="Copy" class="detail_link ml-1">
        <i class="fa fa-files-o" aria-hidden="true"></i>
       </a>
       </label></div>
-     </div>
      {% endfor %}
       {% if selection_form.staff_area.errors %}
         <font class="gbe-form-error">{{ selection_form.staff_area.errors }}</font>
       {% endif %}
-   </div></div>
-   <div class="form-row">
-   <div class="form-group col-12 mb-2" id="filter-button"><br>
+   </div></div></div>
+   <div class="form-group" id="filter-button">
       <input type="submit" class="btn gbe-btn-primary" name="filter" value="Filter">
-   </div></div>
+   </div></div></div>
+   
    Yellow = volunteers must be approved.
    <div class="row"><div class="col-12">&nbsp;</div></div>
 {% endblock %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -26,7 +26,7 @@
    <div class="dropdown col col-md-auto">
     <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
      {{ selection_form.staff_area.label }}</button>
-    <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink"><div class="form-group mb-0">
+    <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink">
      {% for checkbox in selection_form.staff_area %}
       <div class="dropdown-item">
       <label class="checkbox-label gbe-filter mb-0" id="{{ checkbox.id_for_label }}">
@@ -37,7 +37,7 @@
        <i class="fa fa-pencil-square" aria-hidden="true"></i>
       </a>
      {% endif %}
-      &nbsp;<a href="{% url "scheduling:copy_staff_schedule" checkbox.data.value %}" data-toggle="tooltip" title="Copy" class="detail_link ml-1">
+      <a href="{% url "scheduling:copy_staff_schedule" checkbox.data.value %}" data-toggle="tooltip" title="Copy" class="detail_link ml-1">
        <i class="fa fa-files-o" aria-hidden="true"></i>
       </a>
       </label></div>
@@ -47,7 +47,7 @@
       {% if selection_form.staff_area.errors %}
         <font class="gbe-form-error">{{ selection_form.staff_area.errors }}</font>
       {% endif %}
-  </div></div>
+  </div>
     {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
   </div></div>
    

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -13,7 +13,7 @@
       <a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn btn-secondary">+ Create New Event</a>{% endif %}</h2>
    </div><div class="col-md-4 text-right">
   <div class="dropdown show">
-    <a class="btn gbe-btn-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
+    <a class="btn btn-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
  {% for slug in conference_slugs %}
         <a class="dropdown-item" href="{% url 'scheduling:manage_event_list' slug %}?{{ request.GET.urlencode }}">{{slug}}</a>
@@ -24,7 +24,7 @@
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.day %}
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.event_style %}
    <div class="dropdown col col-md-auto">
-    <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
      {{ selection_form.staff_area.label }}</button>
     <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink">
      {% for checkbox in selection_form.staff_area %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -8,16 +8,16 @@
   <div class="col-md-8">
     <h2 class="gbe-title">{{view_title}}{% if conference.status != "completed" %}
       <a href="{% url 'scheduling:create_event_wizard' conference.conference_slug %}" role="button" class="btn btn-secondary">+ Create New Event</a>{% endif %}</h2>
-   </div><div class="col-md-4 text-right">
-  <div class="dropdown show">
+   </div></div>
+<div class="row">
+  <div class="gbe-tab-area my-2 col-auto mr-2"><div class="dropdown pt-2">
     <a class="btn btn-light dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{conference.conference_slug}}</a>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
- {% for slug in conference_slugs %}
+  {% for slug in conference_slugs %}
         <a class="dropdown-item" href="{% url 'scheduling:manage_event_list' slug %}?{{ request.GET.urlencode }}">{{slug}}</a>
- {% endfor %}
-    </div></div></div></div>
- <div class="gbe-tab-area my-2">
-  <div class="btn-group row">
+  {% endfor %}
+  </div></div></div>
+  <div class="gbe-tab-area my-2 col"><div class="btn-group row">
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.day %}
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.event_style %}
    <div class="dropdown col col-md-auto">
@@ -51,8 +51,8 @@
   </div>
   <div class="col col-md-auto mt-1 py-2" id="filter-box">
   </div>
-  </div></div>
-   <div class="row"><div class="col-12">Yellow = volunteers for this event must be approved.</div></div>
+  </div></div></div>
+  <div class="row"><div class="col-12">Yellow = volunteers for this event must be approved.</div></div>
 {% endblock %}
 {% block tbody %}
     {% for occurrence in occurrences %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -49,6 +49,8 @@
   <div class="col col-md-auto">
      <a href="{% url 'scheduling:manage_event_list' conference.conference_slug %}" class="btn gbe-btn-primary mt-1">Clear All Filters</a>
   </div>
+  <div class="col col-md-auto mt-1 py-2" id="filter-box">
+  </div>
   </div></div>
    
    Yellow = volunteers for this event must be approved.
@@ -89,6 +91,9 @@
  </div>
 </div>
 </form>
+{% endblock %}
+{% block on_ready_js %}
+    $('#gbe-table_filter').appendTo( $('#filter-box') );
 {% endblock %}
 
 

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -46,6 +46,9 @@
       {% endif %}
   </div>
     {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
+  <div class="col col-md-auto">
+     <a href="{% url 'scheduling:manage_event_list' conference.conference_slug %}" class="btn gbe-btn-primary mt-1">Clear All Filters</a>
+  </div>
   </div></div>
    
    Yellow = volunteers for this event must be approved.

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -4,9 +4,6 @@
 {% endblock %}
 {% block before_table %}
 <form action="" method="get" enctype="multipart/form-data">
- {% for form in other_forms %}
-  {{ form }}
- {% endfor %}
 <div class="container review"><div class="row">
   <div class="col-md-8">
     <h2 class="gbe-title">{{view_title}}{% if conference.status != "completed" %}

--- a/gbe/templates/gbe/scheduling/manage_event.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event.tmpl
@@ -3,7 +3,7 @@
   Manage Expo Schedule
 {% endblock %}
 {% block before_table %}
-<form class="form-inline" action="" method="get" enctype="multipart/form-data">
+<form action="" method="get" enctype="multipart/form-data">
  {% for form in other_forms %}
   {{ form }}
  {% endfor %}
@@ -20,16 +20,16 @@
  {% endfor %}
     </div></div></div></div>
  <div class="gbe-tab-area my-2">
-  <div class="btn-group">
+  <div class="btn-group row">
    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.day %}
-   {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
-   <div class="dropdown">
+   {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.event_style %}
+   <div class="dropdown col col-md-auto">
     <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="staffMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
      {{ selection_form.staff_area.label }}</button>
-   <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink"><div class="form-group">
+    <div class="dropdown-menu pb-0" aria-labelledby="staffMenuLink"><div class="form-group mb-0">
      {% for checkbox in selection_form.staff_area %}
-      <div class="form-check-inline">
-      <label class="checkbox-label gbe-filter" id="{{ checkbox.id_for_label }}">
+      <div class="dropdown-item">
+      <label class="checkbox-label gbe-filter mb-0" id="{{ checkbox.id_for_label }}">
       {{ checkbox.tag }}
       {{ checkbox.choice_label }}
       {% if conference.status != "completed" %}
@@ -43,11 +43,13 @@
       </label></div>
      {% endfor %}
      <input type="submit" class="btn btn-secondary w-100 mt-2" name="filter" value="Apply">
-   </div>
+    </div>
       {% if selection_form.staff_area.errors %}
         <font class="gbe-form-error">{{ selection_form.staff_area.errors }}</font>
       {% endif %}
-    </div></div></div></div>
+  </div></div>
+    {% include "gbe/scheduling/manage_event_field.tmpl" with field=selection_form.calendar_type %}
+  </div></div>
    
    Yellow = volunteers for this event must be approved.
    <div class="row"><div class="col-12">&nbsp;</div></div>

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,9 +1,9 @@
    <div class="dropdown col col-md-auto">
-    <button class="btn btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label | safe }}</button>
-   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton">
+    <button class="btn btn-light dropdown-toggle m-2" type="button" id="{{ field.label|slugify }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label | safe }}</button>
+   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label|slugify }}MenuButton">
      {% for checkbox in field %}
       <div class="dropdown-item">
-      <label class="checkbox-label gbe-filter mb-0" id="{{ checkbox.id_for_label }}">
+      <label class="checkbox-label gbe-filter mb-0">
       {{ checkbox.tag }}{{ checkbox.label_tag }}{{ checkbox.choice_label }}
       </label>
       </div>{% endfor %}

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,9 +1,9 @@
-   <div class="dropdown">
+   <div class="dropdown col col-md-auto">
     <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
-   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton"><div class="form-group">
+   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton"><div class="form-group mb-0">
      {% for checkbox in field %}
-      <div class="form-check-inline">
-      <label class="checkbox-label gbe-filter" id="{{ checkbox.id_for_label }}">
+      <div class="dropdown-item">
+      <label class="checkbox-label gbe-filter mb-0" id="{{ checkbox.id_for_label }}">
       {{ checkbox.tag }}{{ checkbox.label_tag }}{{ checkbox.choice_label }}
       </label>
       </div>{% endfor %}

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,5 +1,5 @@
    <div class="dropdown col col-md-auto">
-    <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
+    <button class="btn btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
    <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton">
      {% for checkbox in field %}
       <div class="dropdown-item">

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,5 +1,5 @@
    <div class="dropdown col col-md-auto">
-    <button class="btn btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
+    <button class="btn btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label | safe }}</button>
    <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton">
      {% for checkbox in field %}
       <div class="dropdown-item">

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,11 +1,12 @@
    <div class="dropdown">
     <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
-   <div class="dropdown-menu" aria-labelledby="{{ field.label }}MenuButton"><div class="form-group">
+   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton"><div class="form-group">
      {% for checkbox in field %}
       <div class="form-check-inline">
       <label class="checkbox-label gbe-filter" id="{{ checkbox.id_for_label }}">
       {{ checkbox.tag }}{{ checkbox.label_tag }}{{ checkbox.choice_label }}
       </label>
       </div>{% endfor %}
+      <input type="submit" class="btn btn-secondary w-100 mt-2" name="filter" value="Apply">
    </div></div>
    {% if field.errors %}<font class="gbe-form-error">{{ field.errors }}</font>{% endif %}</div>

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,15 +1,11 @@
-   <div class="form-row"><div class="form-group col-md-2 col-12">
-    <label class="form-check-label horizontal-label" id="{{ field.name }}"><b>
-     {% if field.errors %}<font class="gbe-form-error">!&nbsp;&nbsp;{% endif %}
-     {{ field.label }}:&nbsp;&nbsp;
-     {% if field.errors %}</font>{% endif %}</b></label>
-   </div>
-   <div class="form-group col-md-10 col-12">
+   <div class="dropdown">
+    <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
+   <div class="dropdown-menu" aria-labelledby="{{ field.label }}MenuButton"><div class="form-group">
      {% for checkbox in field %}
       <div class="form-check-inline">
       <label class="checkbox-label gbe-filter" id="{{ checkbox.id_for_label }}">
       {{ checkbox.tag }}{{ checkbox.label_tag }}{{ checkbox.choice_label }}
       </label>
       </div>{% endfor %}
-      {% if field.errors %}<font class="gbe-form-error">{{ field.errors }}</font>{% endif %}
    </div></div>
+   {% if field.errors %}<font class="gbe-form-error">{{ field.errors }}</font>{% endif %}</div>

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,5 +1,5 @@
-   <div class="dropdown col col-md-auto">
-    <button class="btn btn-light dropdown-toggle m-2" type="button" id="{{ field.label|slugify }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label | safe }}</button>
+   <div class="dropdown col col-md-auto px-2">
+    <button class="btn btn-light btn-sm dropdown-toggle mt-2" type="button" id="{{ field.label|slugify }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label | safe }}</button>
    <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label|slugify }}MenuButton">
      {% for checkbox in field %}
       <div class="dropdown-item">

--- a/gbe/templates/gbe/scheduling/manage_event_field.tmpl
+++ b/gbe/templates/gbe/scheduling/manage_event_field.tmpl
@@ -1,6 +1,6 @@
    <div class="dropdown col col-md-auto">
     <button class="btn gbe-btn-light dropdown-toggle m-2" type="button" id="{{ field.label }}MenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ field.label }}</button>
-   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton"><div class="form-group mb-0">
+   <div class="dropdown-menu pb-0" aria-labelledby="{{ field.label }}MenuButton">
      {% for checkbox in field %}
       <div class="dropdown-item">
       <label class="checkbox-label gbe-filter mb-0" id="{{ checkbox.id_for_label }}">
@@ -8,5 +8,5 @@
       </label>
       </div>{% endfor %}
       <input type="submit" class="btn btn-secondary w-100 mt-2" name="filter" value="Apply">
-   </div></div>
+   </div>
    {% if field.errors %}<font class="gbe-form-error">{{ field.errors }}</font>{% endif %}</div>

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -61,14 +61,19 @@ event_type_options = [(
         ('staff', 'Staff Area'),
         ('volunteer', 'Volunteering'), ), ), ]
 
-flat_event_type_only = [
-    ('drop-in', 'Drop-In Class'),
-    ('conference', 'Conference Class'),
-    ('master', 'Master Class'),
-    ('show', 'Show'),
-    ('special', 'Special Event'),
-    ('rehearsal', 'Rehearsal Slot'),
-    ('volunteer', 'Volunteering')]
+# our event style setting had no canonical list.  This is not that list.
+# Fix it, reuse it - Betty 2/18/23
+event_styles_complete = [
+    ('Drop-In', 'Drop-In Class'),
+    ('Lecture', "Lecture"),
+    ('Master', 'Master Class'),
+    ('Movement', "Movement"),
+    ('Panel', "Panel"),
+    ('Rehearsal Slot', 'Rehearsal Slot'),
+    ('Show', 'Show'),
+    ('Special', 'Special Event'),
+    ('Volunteer', 'Volunteering'),
+    ('Workshop', "Workshop")]
 
 event_settings = {
     'drop-in': {

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -61,6 +61,15 @@ event_type_options = [(
         ('staff', 'Staff Area'),
         ('volunteer', 'Volunteering'), ), ), ]
 
+flat_event_type_only = [
+    ('drop-in', 'Drop-In Class'),
+    ('conference', 'Conference Class'),
+    ('master', 'Master Class'),
+    ('show', 'Show'),
+    ('special', 'Special Event'),
+    ('rehearsal', 'Rehearsal Slot'),
+    ('volunteer', 'Volunteering')]
+
 event_settings = {
     'drop-in': {
         'event_type': 'Drop-In Class',

--- a/static/styles/base.css
+++ b/static/styles/base.css
@@ -423,7 +423,6 @@ span.opps-errors ul li{list-style-type: none;}
 span.opps-errors ul {padding: 0px;}
 
 .gbe-filter {margin-left: 10px;padding-left: 20px;}
-.staff-checkbox-label{position:relative;display:inline-block;padding-left:0px;padding-top:5px;margin-bottom:0;margin-left:3px;vertical-align:middle;font-weight:400;cursor:pointer}
 .checkbox-box{border-radius: 15px;border-style: solid; border-width: 1px;padding-bottom: 3px;}
 .checkbox-box-success{margin-top: 5px;padding: 0px 2px 5px 2px;}
 .vol_header {padding: 0 3px 0 3px;}

--- a/templates/dropdown.tmpl
+++ b/templates/dropdown.tmpl
@@ -7,7 +7,7 @@
   {%else%}
     <li><a class="dropdown-item gbe_dropdown"  id="gbe_dropdown" href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">
         {{ child.get_menu_title }}
-    </a>
+    </a></li>
   {%endif%}
 
     {% if child.children %}
@@ -15,5 +15,4 @@
         {% show_menu from_level to_level extra_inactive extra_active "dropdown.tmpl" "" "" child %}
         </ul>
     {% endif %}
-    </li>
 {% endfor %}

--- a/tests/gbe/scheduling/test_manage_events.py
+++ b/tests/gbe/scheduling/test_manage_events.py
@@ -81,29 +81,6 @@ class TestManageEventList(TestCase):
             checked)
         self.assertContains(response, assert_string, html=True)
 
-    def assert_hidden_input_selected(
-            self,
-            response,
-            conf_slug,
-            input_field,
-            input_index,
-            value,
-            exists=True):
-        template_input = '<input type="hidden" name="%s-%s" value="%d"' + \
-            ' id="id_%s-%s_%d" />'
-
-        assert_string = template_input % (
-            conf_slug,
-            input_field,
-            value,
-            conf_slug,
-            input_field,
-            input_index)
-        if exists:
-            self.assertContains(response, assert_string, html=True)
-        else:
-            self.assertNotContains(response, assert_string, html=True)
-
     def test_no_login_gives_error(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
Refactored to align with:

https://www.figma.com/file/Pk1Of5sOwOdrjftUqiegaL/BurlExpo-Site?node-id=5%3A414

But also with some other discussed changes:
- added an Event Styles filter - which required creating a ground-truth list of what our event styles ARE
- Move the conference slug switch to the same filter box "line" but in a separate card so it's clear that it works different (a higher level switch that defines the other filters)
- Remove the filter persistence between tabs because the tabs are gone and this functionality was irrelevantly subtle and excessive
- Add a clear button because a bunch of different switches turned on is really annoying to clear one by one.

This filter is ... OK ... on mobile, but not great.  Fortunately, the rest of the table has always been rather awful, so not a big deal - the chance of someone using this on a phone is low

No new uncovered LOC.
All tests pass
pepdiff = all set

#397 