### PR TITLE
GBE-373: update bootstrap and help text

### DIFF
--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -723,8 +723,10 @@ link_event_labels = {
 link_event_help_text = {
     'display_icon': '''What is shown on the 'I Want to Buy Tickets'
         page.  Description is not shown there, it's pulled from BPT but not
-        shown.  Display Icon must come from http://simplelineicons.com/
-        -- NOTE:  Avoid the "."'''
+        shown.  Display Icon must come from http://simplelineicons.com/ or 
+        https://icons.getbootstrap.com/ (version 1.10.2)
+        -- NOTE:  use only the icon class, for example 
+        <i class="JUST USE THIS STUFF"></i>'''
 }
 ticketing_event_labels = {
     'act_submission_event': 'Act Submission Fee?:',
@@ -747,7 +749,8 @@ ticketing_event_help_text = {
     'include_conference': 'All Classes, Panels and Workshops are included.',
     'include_most': ('Everything except Master Classes and Volunteer '
                      'Opportunities'),
-    'ticket_style': 'Special instructions for Reg Desk'
+    'ticket_style': 'Special instructions for Reg Desk',
+    'display_icon': link_event_help_text['display_icon'],
 }
 
 donation_labels = {'donation': 'Fee (pay what you will)'}

--- a/gbe_forms_text.py
+++ b/gbe_forms_text.py
@@ -723,9 +723,9 @@ link_event_labels = {
 link_event_help_text = {
     'display_icon': '''What is shown on the 'I Want to Buy Tickets'
         page.  Description is not shown there, it's pulled from BPT but not
-        shown.  Display Icon must come from http://simplelineicons.com/ or 
+        shown.  Display Icon must come from http://simplelineicons.com/ or
         https://icons.getbootstrap.com/ (version 1.10.2)
-        -- NOTE:  use only the icon class, for example 
+        -- NOTE:  use only the icon class, for example
         <i class="JUST USE THIS STUFF"></i>'''
 }
 ticketing_event_labels = {

--- a/ticketing/admin.py
+++ b/ticketing/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from ticketing.models import *
+from gbe_forms_text import link_event_help_text
 
 
 class BrownPaperSettingsAdmin(admin.ModelAdmin):
@@ -112,12 +113,7 @@ class TicketingEventsAdmin(admin.ModelAdmin):
         }),
         ("Display Text", {
             'fields': ('display_icon', 'title', 'description'),
-            'description': '''What is shown on the 'I Want to Buy Tickets'
-                page.  Description is not shown there, it's pulled from
-                ticket source but not shown.  Display Icon must come from
-                https://simplelineicons.github.io/ or
-                https://icons.getbootstrap.com/ -- NOTE:  Use only the
-                classes, the i tag is already in the code.''',
+            'description': link_event_help_text['display_icon'],
         }),
     )
 

--- a/ticketing/templates/ticketing/purchase_tickets.tmpl
+++ b/ticketing/templates/ticketing/purchase_tickets.tmpl
@@ -2,8 +2,7 @@
 {% load static cms_tags %}
 {% block head %}
   {% include "gray_grids_css.tmpl" %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
-{% endblock head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.css" integrity="sha384-b6lVK+yci+bfDmaY1u0zE8YYJt0TZxLEAFyYSLHId4xoVvsrQu3INevFKo+Xir8e" crossorigin="anonymous">{% endblock head %}
 
 {% block title %}
   Great Burlesque Exposition


### PR DESCRIPTION
Now using current latest bootstrap
Updated the text to say specifically which version of bootstrap, and to give an example.

Warning - the Admin side has a problem - I can't show HTML, so my example case doesn't work.  But the me-made forms have working help text.