### PR TITLE
update post-office to fix Admin HTML email view

### DIFF
--- a/addons/aldryn-django-cms/aldryn_config.py
+++ b/addons/aldryn-django-cms/aldryn_config.py
@@ -205,6 +205,10 @@ class Form(forms.BaseForm):
         # django-robots
         settings['INSTALLED_APPS'].append('robots')
 
+        settings['MIGRATION_COMMANDS'].append(
+            'python manage.py cms fix-tree'
+        )
+
         # default plugins
         settings['INSTALLED_APPS'].extend([
             # required by aldryn-forms

--- a/addons/django-filer/aldryn_config.py
+++ b/addons/django-filer/aldryn_config.py
@@ -8,7 +8,9 @@ class Form(forms.BaseForm):
 
         from aldryn_addons.utils import boolean_ish, djsenv
         from aldryn_django import storage
+        from easy_thumbnails.conf import Settings as EasySettings
 
+        EasyThumbnailSettings = EasySettings(isolated=True)
         env = partial(djsenv, settings=settings)
 
         # django-filer
@@ -29,16 +31,15 @@ class Form(forms.BaseForm):
         # easy-thumbnails
         settings['THUMBNAIL_QUALITY'] = env('THUMBNAIL_QUALITY', 90)
         settings['THUMBNAIL_PRESERVE_EXTENSIONS'] = ['png', 'gif']
-        settings['THUMBNAIL_PROCESSORS'] = (
-            'easy_thumbnails.processors.colorspace',
-            'easy_thumbnails.processors.autocrop',
-            'filer.thumbnail_processors.scale_and_crop_with_subject_location',
-            'easy_thumbnails.processors.filters',
-        )
-        settings['THUMBNAIL_SOURCE_GENERATORS'] = (
-            'easy_thumbnails.source_generators.pil_image',
-        )
         settings['THUMBNAIL_CACHE_DIMENSIONS'] = True
+
+        # Swap scale and crop for django-filer version
+        settings['THUMBNAIL_PROCESSORS'] = tuple([
+            processor
+            if processor != 'easy_thumbnails.processors.scale_and_crop'
+            else 'filer.thumbnail_processors.scale_and_crop_with_subject_location'
+            for processor in EasyThumbnailSettings.THUMBNAIL_PROCESSORS
+        ])
 
         # easy_thumbnails uses django's default storage backend (local file
         # system storage) by default, even if the DEFAULT_FILE_STORAGE setting

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-addons/2.1.0/ea070c92-bab4-4d6c-aea0-59b99579885f/aldryn-addons-2.1.0.tar.gz#egg=aldryn-addons==2.1.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-django/3.2.18.0/f4beb3e0-9f27-4441-802d-906f6ed9ac1d/aldryn-django-3.2.18.0.tar.gz#egg=aldryn-django==3.2.18.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-sso/2.1.0/e29cc97c-b0f6-49d9-a46f-ed1a34cc9bf7/aldryn-sso-2.1.0.tar.gz#egg=aldryn-sso==2.1.0
-https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-django-cms/3.11.0.1/a6ca94bc-f20d-4a9f-b1c7-e330e34d70b4/aldryn-django-cms-3.11.0.1.tar.gz#egg=aldryn-django-cms==3.11.0.1
+https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-django-cms/3.11.1.0/7a6cb951-9840-4fd2-b734-36a2d49d41d8/aldryn-django-cms-3.11.1.0.tar.gz#egg=aldryn-django-cms==3.11.1.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-common/1.0.4/1021e5a2-d7d6-4dde-8976-c2db74c52c68/aldryn-common-1.0.4.tar.gz#egg=aldryn-common==1.0.4
 https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-bootstrap4/2.0.0/21ac21c0-bccc-429c-bc91-8bb9e0834f45/djangocms-bootstrap4-2.0.0.tar.gz#egg=djangocms-bootstrap4==2.0.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-file/3.0.0/3d2621db-220e-4e62-a731-f651d6c81fc6/djangocms-file-3.0.0.tar.gz#egg=djangocms-file==3.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # <INSTALLED_ADDONS>  # Warning: text inside the INSTALLED_ADDONS tags is auto-generated. Manual changes will be overwritten.
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-addons/2.1.0/ea070c92-bab4-4d6c-aea0-59b99579885f/aldryn-addons-2.1.0.tar.gz#egg=aldryn-addons==2.1.0
-https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-django/3.2.16.0/08980d9b-eb8c-421e-bcb5-aa9d44b69901/aldryn-django-3.2.16.0.tar.gz#egg=aldryn-django==3.2.16.0
+https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-django/3.2.18.0/f4beb3e0-9f27-4441-802d-906f6ed9ac1d/aldryn-django-3.2.18.0.tar.gz#egg=aldryn-django==3.2.18.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-sso/2.1.0/e29cc97c-b0f6-49d9-a46f-ed1a34cc9bf7/aldryn-sso-2.1.0.tar.gz#egg=aldryn-sso==2.1.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-django-cms/3.11.0.1/a6ca94bc-f20d-4a9f-b1c7-e330e34d70b4/aldryn-django-cms-3.11.0.1.tar.gz#egg=aldryn-django-cms==3.11.0.1
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-common/1.0.4/1021e5a2-d7d6-4dde-8976-c2db74c52c68/aldryn-common-1.0.4.tar.gz#egg=aldryn-common==1.0.4

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-snippet/3.0.0/43670
 https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-style/3.0.0/7f83861c-9e68-4dcc-949b-48d429e4fead/djangocms-style-3.0.0.tar.gz#egg=djangocms-style==3.0.0
 https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-text-ckeditor/3.9.1/b5b1bd77-b935-40a0-9ac2-0f64ec4a1bfb/djangocms-text-ckeditor-3.9.1.tar.gz#egg=djangocms-text-ckeditor==3.9.1
 https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-video/3.0.0/a36bdd84-5189-4d20-9ad9-eab9e64d9e25/djangocms-video-3.0.0.tar.gz#egg=djangocms-video==3.0.0
-https://divio-addons.s3-eu-central-1.amazonaws.com/django-filer/2.2.3/2d33931e-e292-42d8-bda8-ddcdcd4d23ce/django-filer-2.2.3.tar.gz#egg=django-filer==2.2.3
+https://divio-addons.s3-eu-central-1.amazonaws.com/django-filer/2.2.4/fec06386-b801-4861-b100-b48310c26ff7/django-filer-2.2.4.tar.gz#egg=django-filer==2.2.4
 # </INSTALLED_ADDONS>
 django-tempus-dominus
 django-formtools

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ https://divio-addons.s3-eu-central-1.amazonaws.com/django-filer/2.2.3/2d33931e-e
 # </INSTALLED_ADDONS>
 django-tempus-dominus
 django-formtools
-django-post_office==3.6.1
+django-post_office
 django-model-utils
 django-import-export
 django-recaptcha2

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,29 +32,29 @@ aldryn-snake==2.0.0
     #   aldryn-django-cms
 https://divio-addons.s3-eu-central-1.amazonaws.com/aldryn-sso/2.1.0/e29cc97c-b0f6-49d9-a46f-ed1a34cc9bf7/aldryn-sso-2.1.0.tar.gz#egg=aldryn-sso==2.1.0
     # via -r /workspace/requirements.in
-asgiref==3.5.2
+asgiref==3.6.0
     # via django
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
-bleach==5.0.1
+bleach[css]==6.0.0
     # via django-post-office
-boto3==1.26.5
+boto3==1.26.105
     # via django-storages
-botocore==1.29.5
+botocore==1.29.105
     # via
     #   boto3
     #   s3transfer
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   requests
     #   sentry-sdk
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
     #   aldryn-client
     #   aldryn-django
-coverage[toml]==6.5.0
+coverage[toml]==7.2.2
     # via
     #   -r /workspace/requirements.in
     #   pytest-cov
@@ -64,7 +64,7 @@ defusedxml==0.7.1
     # via odfpy
 diff-match-patch==20200713
     # via django-import-export
-dj-database-url==1.0.0
+dj-database-url==1.3.0
     # via aldryn-django
 dj-email-url==1.0.6
     # via aldryn-django
@@ -80,9 +80,9 @@ django-appconf==1.0.5
     #   django-select2
 django-autocomplete-light==3.9.0rc1
     # via -r /workspace/requirements.in
-django-cache-url==3.4.2
+django-cache-url==3.4.4
     # via aldryn-django
-django-classy-tags==3.0.1
+django-classy-tags==4.0.0
     # via
     #   django-cms
     #   django-sekizai
@@ -100,9 +100,9 @@ django-cms==3.11.0
     #   djangocms-style
     #   djangocms-text-ckeditor
     #   djangocms-video
-django-compressor==4.1
+django-compressor==4.3.1
     # via aldryn-django-cms
-django-debug-toolbar==3.7.0
+django-debug-toolbar==4.0.0
     # via -r /workspace/requirements.in
 https://divio-addons.s3-eu-central-1.amazonaws.com/django-filer/2.2.3/2d33931e-e292-42d8-bda8-ddcdcd4d23ce/django-filer-2.2.3.tar.gz#egg=django-filer==2.2.3
     # via
@@ -120,11 +120,11 @@ django-getenv==1.3.2
     # via
     #   aldryn-addons
     #   aldryn-django
-django-import-export==3.0.1
+django-import-export==3.1.0
     # via -r /workspace/requirements.in
 django-js-asset==2.0.0
     # via django-mptt
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r /workspace/requirements.in
 django-mptt==0.14.0
     # via django-filer
@@ -134,7 +134,7 @@ django-paypal==2.0
     # via -r /workspace/requirements.in
 django-polymorphic==3.1.0
     # via django-filer
-django-post_office==3.6.1
+django-post-office==3.6.3
     # via -r /workspace/requirements.in
 django-ranged-response==0.2.0
     # via django-simple-captcha
@@ -144,11 +144,11 @@ django-robots==5.0
     # via aldryn-django-cms
 django-sekizai==4.0.0
     # via django-cms
-django-select2==8.0.0
+django-select2==8.1.1
     # via aldryn-django-cms
 django-simple-captcha==0.5.17
     # via aldryn-django-cms
-django-simple-sso==1.1.0
+django-simple-sso==1.2.0
     # via aldryn-sso
 django-sortedm2m==3.1.1
     # via
@@ -156,7 +156,7 @@ django-sortedm2m==3.1.1
     #   aldryn-django-cms
 django-storage-url==0.9.2
     # via aldryn-django
-django-storages[boto3]==1.13.1
+django-storages[boto3]==1.13.2
     # via
     #   aldryn-django
     #   django-storage-url
@@ -201,7 +201,7 @@ django==3.2.16
     #   easy-thumbnails
     #   jsonfield
     #   webservices
-djangocms-admin-style==3.2.0
+djangocms-admin-style==3.2.3
     # via
     #   aldryn-django-cms
     #   django-cms
@@ -242,7 +242,7 @@ https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-text-ckeditor/3.9.1
     #   djangocms-bootstrap4
 https://divio-addons.s3-eu-central-1.amazonaws.com/djangocms-video/3.0.0/a36bdd84-5189-4d20-9ad9-eab9e64d9e25/djangocms-video-3.0.0.tar.gz#egg=djangocms-video==3.0.0
     # via -r /workspace/requirements.in
-easy-thumbnails[svg]==2.8.3
+easy-thumbnails[svg]==2.8.5
     # via
     #   aldryn-django
     #   django-filer
@@ -251,11 +251,11 @@ et-xmlfile==1.1.0
     # via openpyxl
 eventbrite==3.3.5
     # via -r /workspace/requirements.in
-exceptiongroup==1.0.1
+exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r /workspace/requirements.in
-faker==15.3.1
+faker==18.3.2
     # via factory-boy
 furl==2.1.3
     # via
@@ -266,7 +266,7 @@ html5lib==1.1
     # via djangocms-text-ckeditor
 idna==3.4
     # via requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 itsdangerous==0.24
     # via
@@ -278,25 +278,25 @@ jmespath==1.0.1
     #   botocore
 jsonfield==3.1.0
     # via django-post-office
-lxml==4.9.1
+lxml==4.9.2
     # via
     #   aldryn-django-cms
     #   svglib
 markuppy==1.14
     # via tablib
-mock==4.0.3
+mock==5.0.1
     # via -r /workspace/requirements.in
 odfpy==1.4.1
     # via tablib
-openpyxl==3.0.10
+openpyxl==3.1.2
     # via tablib
 orderedmultidict==1.0.1
     # via furl
-packaging==21.3
+packaging==23.0
     # via pytest
 pep8==1.7.1
     # via -r /workspace/requirements.in
-pillow==9.3.0
+pillow==9.5.0
     # via
     #   -r /workspace/requirements.in
     #   django-simple-captcha
@@ -305,15 +305,13 @@ pillow==9.3.0
     #   reportlab
 pluggy==1.0.0
     # via pytest
-psycopg2==2.9.5
+psycopg2==2.9.6
     # via aldryn-django
-pyparsing==3.0.9
-    # via packaging
 pytest-cov==4.0.0
     # via -r /workspace/requirements.in
 pytest-django==4.5.2
     # via -r /workspace/requirements.in
-pytest==7.2.0
+pytest==7.2.2
     # via
     #   -r /workspace/requirements.in
     #   pytest-cov
@@ -322,7 +320,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   faker
-pytz==2022.6
+pytz==2023.3
     # via
     #   -r /workspace/requirements.in
     #   django
@@ -330,14 +328,14 @@ pytz==2022.6
     #   django-post-office
 pyyaml==6.0
     # via tablib
-rcssmin==1.1.0
+rcssmin==1.1.1
     # via django-compressor
 reportlab==3.6.12
     # via
     #   -r /workspace/requirements.in
     #   easy-thumbnails
     #   svglib
-requests==2.28.1
+requests==2.28.2
     # via
     #   aldryn-client
     #   aldryn-django-cms
@@ -345,11 +343,11 @@ requests==2.28.1
     #   django-recaptcha2
     #   eventbrite
     #   webservices
-rjsmin==1.2.0
+rjsmin==1.2.1
     # via django-compressor
 s3transfer==0.6.0
     # via boto3
-sentry-sdk==1.10.1
+sentry-sdk==1.19.0
     # via aldryn-django
 six==1.16.0
     # via
@@ -365,25 +363,28 @@ sqlparse==0.4.3
     # via
     #   django
     #   django-debug-toolbar
-svglib==1.4.1
+svglib==1.5.1
     # via easy-thumbnails
-tablib[html,ods,xls,xlsx,yaml]==3.2.1
+tablib[html,ods,xls,xlsx,yaml]==3.3.0
     # via
     #   -r /workspace/requirements.in
     #   django-import-export
 tabulate==0.8.10
     # via aldryn-client
-tinycss2==1.2.1
+tinycss2==1.1.1
     # via
+    #   bleach
     #   cssselect2
     #   svglib
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
+typing-extensions==4.5.0
+    # via dj-database-url
 unidecode==1.1.2
     # via django-filer
-urllib3==1.26.12
+urllib3==1.26.15
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
Turns out, the post-office library folks found a fix to their problem.  I had had to pin the post-office version for some reason or another, but when I retried the update, all went well.

No code changes needed, this is just updating versions of what we include.
