### PR TITLE
Gbe 423 & 424:  Longer view - mail only staff leads, use vol coordinator only when there is no lead

### DIFF
--- a/gbe/email/functions.py
+++ b/gbe/email/functions.py
@@ -364,9 +364,7 @@ def send_volunteer_update_to_staff(
         name,
         "volunteer_schedule_change",
         "Volunteer Schedule Change")
-    to_list = [user.email for user in
-               User.objects.filter(groups__name='Volunteer Coordinator',
-                                   is_active=True)]
+    to_list = []
     leads = get_all_container_bookings(
         occurrence_ids=[occurrence.pk],
         roles=['Staff Lead', ])
@@ -379,6 +377,13 @@ def send_volunteer_update_to_staff(
             staff_lead__isnull=False):
         if area.staff_lead.user_object.email not in to_list:
             to_list += [area.staff_lead.user_object.email]
+
+    # only mail to coordinators if there are no staff leads
+    if len(to_list) == 0:
+        to_list = [user.email for user in User.objects.filter(
+            groups__name='Volunteer Coordinator',
+            is_active=True)]
+
     state_change = ""
     if state == "on":
         if occurrence.approval_needed:

--- a/static/styles/gray_grids_css/main.css
+++ b/static/styles/gray_grids_css/main.css
@@ -56,6 +56,7 @@ fieldset[disabled] .btn {
   position: relative;
   margin-bottom: 10px;
   padding-top: 15px;
+  padding-bottom: 30px;
 }
 .gallery-item .overlay {
   position: absolute;

--- a/tests/gbe/scheduling/test_set_volunteer_view.py
+++ b/tests/gbe/scheduling/test_set_volunteer_view.py
@@ -297,7 +297,7 @@ class TestSetVolunteer(TestCase):
             class_context.bid.b_title,
             class_context.sched_event.starttime.strftime(GBE_DATETIME_FORMAT))
         assert(class_context.bid.b_title in staff_msg.body)
-        # even though there is a volunteer coordinator - mail only goes to 
+        # even though there is a volunteer coordinator - mail only goes to
         # staff lead
         assert_email_recipient(
             [self.context.staff_lead.profile.user_object.email],

--- a/tests/gbe/scheduling/test_set_volunteer_view.py
+++ b/tests/gbe/scheduling/test_set_volunteer_view.py
@@ -297,9 +297,10 @@ class TestSetVolunteer(TestCase):
             class_context.bid.b_title,
             class_context.sched_event.starttime.strftime(GBE_DATETIME_FORMAT))
         assert(class_context.bid.b_title in staff_msg.body)
+        # even though there is a volunteer coordinator - mail only goes to 
+        # staff lead
         assert_email_recipient(
-            [self.privileged_user.email,
-             self.context.staff_lead.profile.user_object.email],
+            [self.context.staff_lead.profile.user_object.email],
             outbox_size=2,
             message_index=1)
         self.assertContains(response, conflict_msg)
@@ -334,6 +335,23 @@ class TestSetVolunteer(TestCase):
             message_index=1)
         self.assertContains(response, conflict_msg)
         assert(conflict_msg in staff_msg.body)
+
+    def test_mail_vol_coordinator_when_no_lead(self):
+        self.privileged_profile = ProfileFactory()
+        self.privileged_user = self.privileged_profile.user_object
+        grant_privilege(self.privileged_user, 'Volunteer Coordinator')
+        vol_context = VolunteerContext(
+            conference=self.context.conference)
+        url = reverse(
+            self.view_name,
+            args=[vol_context.opp_event.pk, "on"],
+            urlconf="gbe.scheduling.urls")
+        login_as(self.profile, self)
+        response = self.client.post(url, follow=True)
+        assert_email_recipient(
+            [self.privileged_user.email],
+            outbox_size=2,
+            message_index=1)
 
     def test_email_fail(self):
         self.context.area.staff_lead = self.profile


### PR DESCRIPTION
Per conversation on #423 
- reduced the audience to any staff lead associated with the event the volunteer signed up for (or withdrew from)
- it still emails for ALL add/remove activity by the volunteer whether or not the event requires approval - but only to the staff lead
- we do have shifts that aren't in a staff area - since that is possible - if there is no area, or no lead - the volunteer coordinator gets an email.

Testing looks good
Pepdiff is good
Running coverage test now

Added #424 because it is 1 line.

**NOTE TO SELF** - update notes in the email template and the wiki when you publish this, so the change is logic is clear.