### PR TITLE
Gbe 441:  Act role in 3 places

### DIFF
--- a/gbe/reporting/views/act_tech_list.py
+++ b/gbe/reporting/views/act_tech_list.py
@@ -45,6 +45,7 @@ class ActTechList(View):
 
         header = ['Order',
                   'Performer',
+                  'Role',
                   'Title',
                   'Duration (HH:MM:SS)',
                   'Starting Position',
@@ -77,6 +78,7 @@ class ActTechList(View):
             background = "No selection made"
             cue = "NONE"
             order = -1
+            role = ""
             act = get_object_or_404(
                 Act,
                 pk=performer.commitment.class_id)
@@ -89,6 +91,7 @@ class ActTechList(View):
             for item in sched_response.schedule_items:
                 if item.event.event_style == "Show":
                     order = item.commitment.order
+                    role = item.commitment.role
             if act.tech.prop_setup:
                 for item in act.tech.prop_setup_list:
                     if len(prop_setup_list) == 0:
@@ -122,6 +125,7 @@ class ActTechList(View):
             tech_info.append([
                 order,
                 str(act.performer),
+                role,
                 act.b_title,
                 act.tech.duration,
                 act.tech.starting_position,

--- a/gbe/reporting/views/act_techinfo_detail.py
+++ b/gbe/reporting/views/act_techinfo_detail.py
@@ -22,6 +22,7 @@ def act_techinfo_detail(request, act_id):
     shows = []
     rehearsals = []
     order = -1
+    role = "NO ROLE"
 
     act = get_object_or_404(Act, pk=act_id)
     # if this isn't a privileged user, it had better be a member of the
@@ -45,6 +46,7 @@ def act_techinfo_detail(request, act_id):
                     item.event.event_style == 'Show'):
                 shows += [item.event]
                 order = item.commitment.order
+                role = item.commitment.role
             elif item.event not in rehearsals and (
                     item.event.event_style == 'Rehearsal Slot'):
                 rehearsals += [item.event]
@@ -55,4 +57,5 @@ def act_techinfo_detail(request, act_id):
                    'state': acceptance_states[act.accepted][1],
                    'shows': shows,
                    'order': order,
+                   'role': role,
                    'rehearsals': rehearsals})

--- a/gbe/scheduling/views/show_dashboard.py
+++ b/gbe/scheduling/views/show_dashboard.py
@@ -154,6 +154,7 @@ class ShowDashboard(ProfileRequiredMixin, View):
                    'Tech Done',
                    'Act',
                    'Performer',
+                   'Role',
                    'Rehearsal',
                    'Music',
                    'Action']
@@ -166,6 +167,7 @@ class ShowDashboard(ProfileRequiredMixin, View):
         for performer in response.people:
             rehearsals = []
             order = -1
+            show_role = "NO ROLE"
             act = get_object_or_404(
                 Act,
                 pk=performer.commitment.class_id)
@@ -181,6 +183,7 @@ class ShowDashboard(ProfileRequiredMixin, View):
                     rehearsals += [item]
                 elif item.event.event_style == "Show":
                     order = item.commitment.order
+                    show_role = item.commitment.role
             if request.POST:
                 form = ActScheduleBasics(
                     request.POST,
@@ -203,6 +206,7 @@ class ShowDashboard(ProfileRequiredMixin, View):
                 'act': act,
                 'rehearsals': rehearsals,
                 'order': order,
+                'show_role': show_role,
                 'rebook_form': rebook_form,
                 'form': form}]
 

--- a/gbe/templates/gbe/report/act_tech_detail.tmpl
+++ b/gbe/templates/gbe/report/act_tech_detail.tmpl
@@ -16,6 +16,7 @@ Act state is {{ state }}</span>
  <div class="col-xs-12 col-md-6 col-lg-4">
   <h2 class="gbe-title">Performer: {{act.performer}}</H2>
   <h3 class="gbe-subtitle">Act Name: {{act.b_title}}</h3>
+  <b>Role:</b> {{role}}<br>
   {% if not act.tech.is_complete %}<font class="gbe-form-error">Act Tech is NOT complete</font><br>{% endif %}
   <b>Email:</b>  <a href='mailto:{{act.act.performer.contact.user_object.email}}'>
     {{act.performer.contact.user_object.email}}</a><br>

--- a/gbe/templates/gbe/scheduling/act_tech_table.tmpl
+++ b/gbe/templates/gbe/scheduling/act_tech_table.tmpl
@@ -50,6 +50,7 @@
         {% if not act.act.performer.contact.user_object.is_active  %}- INACTIVE</span>
         {% endif %}<br>
         <a href='mailto:{{act.act.performer.contact.user_object.email}}' class="gbe-table-link">{{act.act.performer.contact.user_object.email}}</a></td>
+      <td>{{ act.show_role }}</td>
       <td>{% if act.act.tech.confirm_no_rehearsal %}Acknowledged No Rehearsal{% else %}{% for rehearsal in act.rehearsals %}{{rehearsal.event.start_time}}<br>{% empty %}Has not signed up{%endfor%}{% endif %}</td>
       <td>{% if act.act.tech.track %}
             <a href="{{act.act.tech.track.url}}" class="gbe-table-link" >{{act.act.tech.track.name | display_track_title:20 }}</a>

--- a/tests/gbe/reports/test_act_tech_list.py
+++ b/tests/gbe/reports/test_act_tech_list.py
@@ -122,3 +122,4 @@ class TestReviewActTechInfo(TestCase):
         login_as(self.profile, self)
         response = self.client.get(self.url)
         self.assertContains(response, "3")
+        self.assertContains(response, self.context.order.role)

--- a/tests/gbe/reports/test_act_techinfo_detail.py
+++ b/tests/gbe/reports/test_act_techinfo_detail.py
@@ -102,6 +102,8 @@ class TestReviewActTechInfo(TestCase):
         self.assertContains(response, date_format(
             self.context.rehearsal.start_time,
             "DATETIME_FORMAT"))
+        self.assertContains(response,
+                            "<b>Role:</b> %s" % self.context.order.role)
 
     def test_review_act_techinfo_advanced(self):
         '''review_act_techinfo view should load for Tech Crew

--- a/tests/gbe/scheduling/test_show_dashboard.py
+++ b/tests/gbe/scheduling/test_show_dashboard.py
@@ -114,6 +114,8 @@ class TestShowDashboard(TestCase):
              self.context.order.order,
              self.context.booking.pk),
             html=True)
+        self.assertContains(response, self.context.order.role)
+
 
     def test_no_techinfo_edit_no_order_change(self):
         '''Act Coordinator can't edit act tech, or the order

--- a/tests/gbe/scheduling/test_show_dashboard.py
+++ b/tests/gbe/scheduling/test_show_dashboard.py
@@ -116,7 +116,6 @@ class TestShowDashboard(TestCase):
             html=True)
         self.assertContains(response, self.context.order.role)
 
-
     def test_no_techinfo_edit_no_order_change(self):
         '''Act Coordinator can't edit act tech, or the order
         This should be an act w/out tech info.


### PR DESCRIPTION
Wasn't sure where it was best, it was easy to put all the places:
- show dashboard - it's on the act list as a new column
- act detail page - it's under the performer's name on the upper left
- act tech csv - it's a new column
