### PR TITLE
Gbe 451: fix to daily emails for troupe members

### DIFF
--- a/gbe/models/profile.py
+++ b/gbe/models/profile.py
@@ -65,6 +65,9 @@ class Profile(WorkerItem):
                           blank=True)
     how_heard = TextField(blank=True)
 
+    def get_profiles(self):
+        return [self]
+
     @property
     def how_heard_list(self):
         if self.how_heard:

--- a/gbe/scheduling/views/show_dashboard.py
+++ b/gbe/scheduling/views/show_dashboard.py
@@ -178,9 +178,9 @@ class ShowDashboard(ProfileRequiredMixin, View):
                                 sched_response,
                                 self.__class__.__name__)
             for item in sched_response.schedule_items:
-                if item not in rehearsals and (
+                if item.event not in rehearsals and (
                         item.event.event_style == "Rehearsal Slot"):
-                    rehearsals += [item]
+                    rehearsals += [item.event]
                 elif item.event.event_style == "Show":
                     order = item.commitment.order
                     show_role = item.commitment.role

--- a/gbe/templates/gbe/scheduling/act_tech_table.tmpl
+++ b/gbe/templates/gbe/scheduling/act_tech_table.tmpl
@@ -51,7 +51,7 @@
         {% endif %}<br>
         <a href='mailto:{{act.act.performer.contact.user_object.email}}' class="gbe-table-link">{{act.act.performer.contact.user_object.email}}</a></td>
       <td>{{ act.show_role }}</td>
-      <td>{% if act.act.tech.confirm_no_rehearsal %}Acknowledged No Rehearsal{% else %}{% for rehearsal in act.rehearsals %}{{rehearsal.event.start_time}}<br>{% empty %}Has not signed up{%endfor%}{% endif %}</td>
+      <td>{% if act.act.tech.confirm_no_rehearsal %}Acknowledged No Rehearsal{% else %}{% for rehearsal in act.rehearsals %}{{rehearsal.starttime}}<br>{% empty %}Has not signed up{%endfor%}{% endif %}</td>
       <td>{% if act.act.tech.track %}
             <a href="{{act.act.tech.track.url}}" class="gbe-table-link" >{{act.act.tech.track.name | display_track_title:20 }}</a>
           {% elif act.act.tech.confirm_no_music %}

--- a/scheduler/idd/get_schedule.py
+++ b/scheduler/idd/get_schedule.py
@@ -73,7 +73,6 @@ def get_schedule(user=None,
                 # TODO - refactor to a schedule side construct, not a GBE side
                 # this covers all troupe members getting included
                 for profile in resource.workeritem.get_profiles():
-                    print("profile: %s, event: %s" % (str(profile), item.event.title))
                     sched_items += [ScheduleItem(
                         user=profile.user_object,
                         event=item.event,

--- a/scheduler/idd/get_schedule.py
+++ b/scheduler/idd/get_schedule.py
@@ -70,13 +70,17 @@ def get_schedule(user=None,
                 order = None
                 if hasattr(item, 'ordering'):
                     order = item.ordering
-                sched_items += [ScheduleItem(
-                    user=resource.workeritem.user_object,
-                    event=item.event,
-                    role=resource.role,
-                    label=booking_label,
-                    booking_id=item.pk,
-                    commitment=order)]
+                # TODO - refactor to a schedule side construct, not a GBE side
+                # this covers all troupe members getting included
+                for profile in resource.workeritem.get_profiles():
+                    print("profile: %s, event: %s" % (str(profile), item.event.title))
+                    sched_items += [ScheduleItem(
+                        user=profile.user_object,
+                        event=item.event,
+                        role=resource.role,
+                        label=booking_label,
+                        booking_id=item.pk,
+                        commitment=order)]
     response = ScheduleResponse(
         schedule_items=sorted(
             set(sched_items),


### PR DESCRIPTION
I believe this is the right fix at the right level.

But because it's seriously in the middle of things, I'm going to PR now, and hot fix the site, rather than fast merge to master.

This takes the IDD layer and updates "get_schedule" to get the schedule items for all people in a unit - so that when the "worker" unit is a troupe, it gets all members.

This is about 1/2 the troupe problem - there's also a "get_people" API that functions similarly where a Troupe = 1 person, the main contact point - that affects badges and the prototyped occupany report -- and still needs to be fixed via a different ticket (already filed).
