### PR TITLE
Make act rehearsal behave properly

### DIFF
--- a/gbe/views/act_tech_wizard_view.py
+++ b/gbe/views/act_tech_wizard_view.py
@@ -138,6 +138,7 @@ class ActTechWizardView(View):
                                         response,
                                         self.__class__.__name__)
                 self.act.tech.confirm_no_rehearsal = False
+                self.act.tech.save()
                 if response.occurrence:
                     bookings += [response.occurrence]
                     self.rehearsals[int(rehearsal_form.prefix)] = ScheduleItem(


### PR DESCRIPTION
2 out of 3 bugs in #454 was fixed by work done in the #troupe-fix and #people-refactor-2 branches - now on main.

The last was that I didn't properly clear confirm_no_rehearsal on tech info when a person books a rehearsal.  it was actually set, but not saved!!

Fixed that and wrote additional test conditions to catch this.

Did not re-do coverage test - bug is just too small.