### PR TITLE
Hotfix to Troupe membership change (#346)

### DIFF
--- a/gbe/forms/act_edit_form.py
+++ b/gbe/forms/act_edit_form.py
@@ -129,7 +129,8 @@ class ActEditForm(ActEditDraftForm):
 
     def clean(self):
         cleaned_data = super(ActEditForm, self).clean()
-        if cleaned_data["num_performers"] > 1 and not (
+        if 'num_performers' in cleaned_data.keys() and (
+                cleaned_data["num_performers"] > 1) and not (
                 cleaned_data.get("performer_names")):
             error = ValidationError(act_group_needs_names)
             self.add_error('performer_names', error)

--- a/gbe/views/make_act_view.py
+++ b/gbe/views/make_act_view.py
@@ -35,6 +35,7 @@ class MakeActView(MakeBidView):
     submit_fields = ['b_title',
                      'b_description',
                      'shows_preferences',
+                     'num_performers',
                      'bio', ]
     bid_type = "Act"
     has_draft = True

--- a/tests/gbe/test_make_act.py
+++ b/tests/gbe/test_make_act.py
@@ -129,7 +129,7 @@ class TestCreateAct(TestMakeAct):
     def test_act_bid_post_form_not_valid(self):
         login_as(self.performer.contact, self)
         url = reverse(self.view_name, urlconf='gbe.urls')
-        data = self.get_act_form(self.performer, submit=True, valid=False)
+        data = {'submit': 1}
         response = self.client.post(url,
                                     data=data)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
As soon as I started working on the Act Title change, I found a bug.  Then 2 bugs.

It's not a problem on live right now, because the bid submission is turned off, so users can't get to the bugs.  But this needed to be fixed before acts are submitted.

Bug 1 - submitting a draft and having an error results in a form where it looks like the # of performers is not required for a final submission - minor issue.
Bug 2 - submitting an act for full submission/payment where the num_performers field is blank causes a crash from an unhandled exception because my custom logic is looking for a # of performers and the field is blank.  Messy programming and very visible - severity high.

So, fixed both with this ticket and tuned up a test to cover the high priority issue.