### PR TITLE
Gbe 458:  Make it possible to have 15 min events

### DIFF
--- a/gbe/scheduling/forms/schedule_basic_form.py
+++ b/gbe/scheduling/forms/schedule_basic_form.py
@@ -19,7 +19,7 @@ time_start = 8 * 60
 time_stop = 24 * 60
 conference_times = [(time(int(mins/60), mins % 60),
                      time(int(mins/60), mins % 60).strftime(GBE_TIME_FORMAT))
-                    for mins in range(time_start, time_stop, 30)]
+                    for mins in range(time_start, time_stop, 15)]
 
 
 class ScheduleBasicForm(Form):
@@ -31,7 +31,7 @@ class ScheduleBasicForm(Form):
         widget=HiddenInput(),
         required=False)
     max_volunteer = IntegerField(required=True)
-    duration = FloatField(min_value=0.5,
+    duration = FloatField(min_value=0.25,
                           max_value=12,
                           required=True)
     day = ChoiceField(choices=['No Days Specified'])

--- a/gbe/scheduling/forms/schedule_occurrence_form.py
+++ b/gbe/scheduling/forms/schedule_occurrence_form.py
@@ -27,7 +27,7 @@ time_start = 8 * 60
 time_stop = 24 * 60
 conference_times = [(time(int(mins/60), mins % 60),
                      time(int(mins/60), mins % 60).strftime(GBE_TIME_FORMAT))
-                    for mins in range(time_start, time_stop, 30)]
+                    for mins in range(time_start, time_stop, 15)]
 
 
 class DayChoiceField(ModelChoiceField):
@@ -43,7 +43,7 @@ class ScheduleOccurrenceForm(Form):
                          empty_label=None,
                          required=True)
     time = ChoiceField(choices=conference_times, required=True)
-    duration = FloatField(min_value=0.5,
+    duration = FloatField(min_value=0.25,
                           max_value=12,
                           required=True,
                           label=schedule_occurrence_labels['duration'])

--- a/gbe/scheduling/views/edit_show_view.py
+++ b/gbe/scheduling/views/edit_show_view.py
@@ -120,7 +120,7 @@ class EditShowView(EditEventView):
                         self).make_context(request, errorcontext=errorcontext)
         initial_rehearsal_info = {
                 'type':  "Rehearsal Slot",
-                'duration': 1.0,
+                'duration': 0.25,
                 'max_volunteer': 10,
                 'day': get_conference_day(
                     conference=self.conference,

--- a/tests/gbe/scheduling/test_edit_event_view.py
+++ b/tests/gbe/scheduling/test_edit_event_view.py
@@ -162,7 +162,7 @@ class TestEditEventView(TestScheduling):
             'name="max_volunteer" value="2"')
         self.assertContains(
             response,
-            '<input type="number" name="duration" value="7.5" min="0.5" ' +
+            '<input type="number" name="duration" value="7.5" min="0.25" ' +
             'max="12" step="any" required id="id_duration">',
             html=True)
 

--- a/tests/gbe/scheduling/test_edit_show_view.py
+++ b/tests/gbe/scheduling/test_edit_show_view.py
@@ -52,9 +52,9 @@ class TestEditShowWizard(TestCase):
             'new_slot-title': 'New Rehearsal Slot',
             'new_slot-event_style': "Rehearsal Slot",
             'new_slot-max_volunteer': '1',
-            'new_slot-duration': '1.0',
+            'new_slot-duration': '0.25',
             'new_slot-day': self.context.days[0].pk,
-            'new_slot-time': '10:00:00',
+            'new_slot-time': '10:15:00',
             'new_slot-location': self.room.pk}
         return data
 
@@ -123,7 +123,7 @@ class TestEditShowWizard(TestCase):
             html=True)
         self.assertContains(
             response,
-            '<input type="number" name="duration" value="7.5" min="0.5" ' +
+            '<input type="number" name="duration" value="7.5" min="0.25" ' +
             'max="12" step="any" required id="id_duration">',
             html=True)
 

--- a/tests/gbe/scheduling/test_edit_volunteer.py
+++ b/tests/gbe/scheduling/test_edit_volunteer.py
@@ -225,7 +225,7 @@ class TestEditVolunteer(TestGBE):
             html=True)
         self.assertContains(
             response,
-            '<input type="number" name="duration" value="2.5" min="0.5" ' +
+            '<input type="number" name="duration" value="2.5" min="0.25" ' +
             'max="12" step="any" required id="id_duration" />',
             html=True)
         self.assertContains(


### PR DESCRIPTION
I decided I might as well set it up universally - not just for rehearsal slots.

So every event can now have:
- a minimum duration of 0.25 (quarter of an hour = 15 min).
- a start time on the hour, 15 past, 30 past and 45 past so slots can be stacked

Easy update, also tweaked a test to cover it.