### PR TITLE
Gbe 366:  Act review summaries

### DIFF
--- a/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -42,7 +42,7 @@
           {% else %}
           Acts with no review at all{% endif %}</td><td>{{ row.count }}</td></tr>
       {% endfor %}
-      <tr class='gbe-table-row'><td><b>Total Acts Pending Review</td><td>{{ review_metrics.total_no_decision }}</b></td></tr>
+      <tr class='gbe-table-row'><td><b>Total Acts Pending Review</b></td><td><b>{{ review_metrics.total_no_decision }}</b></td></tr>
       </tbody></table>
     </div>
   </div></div></div>

--- a/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -11,7 +11,41 @@
         <a class="dropdown-item" href="{% url 'gbe:act_coord_create' %}">Create & Comp Act</a>
         <a class="dropdown-item" href="{% url 'ticketing:comp_ticket' %}?next={{ request.get_full_path }}">Send a Comp</a>
       </div></div>{% endif %}
+      <button class="btn gbe-btn-primary my-3" type="button" data-toggle="collapse" data-target="#actMetricCollapse" aria-expanded="false" aria-controls="actMetricCollapse">
+      Act Review Metrics
+      </button>
   </div></div>
+  <div class="row">
+  <div class="col">
+  <div class="collapse width" id="actMetricCollapse">
+    <div class="card card-body gbe-bg-light border_box">
+      <h4>Act Status</h4>
+      <table>
+      <thead><tr class="gbe-table-header"><th>State</th><th>Count</th></tr></thead>
+      <tbody>
+      {% for act_state, act_count in review_metrics.total_by_status.items %}
+      <tr class="gbe-table-row"><td>{{ act_state }}</td><td>{{ act_count }}</td></tr>
+      {% endfor %}
+      </tbody></table>
+      <br>
+      <h4># of Acts Reviewed, by Reviewer</h4>
+      Only "No Decision" acts are listed here.  Once an act is accepted, rejected, etc, it no longer counts here.<br>
+      <b>All Act Reviewers:</b> {% for reviewer in review_metrics.act_reviewers %}
+      {{reviewer.display_name}}, {% endfor %}
+      <i>Reviewers who have not yet reviewed any acts this year will not be shown in the table below</i>
+      <table>
+      <thead><tr class="gbe-table-header"><th>Reviewer</th><th>Count</th></tr></thead>
+      <tbody>
+      {% for row in review_metrics.total_by_reviewer %}
+      <tr class="gbe-table-row"><td>
+          {% if row.actbidevaluation__evaluator__display_name %}{{ row.actbidevaluation__evaluator__display_name }}
+          {% else %}
+          Acts with no review at all{% endif %}</td><td>{{ row.count }}</td></tr>
+      {% endfor %}
+      <tr class='gbe-table-row'><td><b>Total Acts Pending Review</td><td>{{ review_metrics.total_no_decision }}</b></td></tr>
+      </tbody></table>
+    </div>
+  </div></div></div>
  {% endblock %}
 {% block tbody %}
   {% for row in rows %}

--- a/gbe/templates/gbe/profile/incl_bids.tmpl
+++ b/gbe/templates/gbe/profile/incl_bids.tmpl
@@ -5,8 +5,7 @@
     <br>{{ profile.display_name }} has these bids to review<br>
     <ul>
       {% for review_item in review_items %}
-      <li>{{review_item.bid_type}}:  {{ review_item.bid }} - 
-        <a class="gbe-link" href="{{review_item.url}}">{{ review_item.action }}</a>
+      <li>{{review_item.bid_type}}:  {{ review_item.unreviewed_bids }} out of {{ review_item.total_bids }}{% if review_item.unreviewed_bids > 0 %} - <a class="gbe-link" href="{{review_item.url}}">Review Now</a>{% endif %}
     	</li>
       {% endfor %}
     </ul>

--- a/gbe/views/landing_page_view.py
+++ b/gbe/views/landing_page_view.py
@@ -75,20 +75,10 @@ class LandingPageView(ProfileRequiredMixin, View):
         self.groundwork(request, args, kwargs)
         viewer_profile = self.viewer_profile
         context = {}
-        bids_to_review = []
-
         person = Person(
             users=[viewer_profile.user_object],
             public_id=viewer_profile.pk,
             public_class="Profile")
-        for bid in viewer_profile.bids_to_review():
-            bids_to_review += [{
-                'bid': bid,
-                'url': reverse('%s_review' % bid.__class__.__name__.lower(),
-                               urlconf='gbe.urls',
-                               args=[str(bid.id)]),
-                'action': "Review",
-                'bid_type': bid.__class__.__name__}]
         response = get_bookable_people_by_user(self.viewer_profile.user_object)
         bio_ids = []
         # we want both bios the user is included in and bios the user is
@@ -183,7 +173,7 @@ class LandingPageView(ProfileRequiredMixin, View):
                 self.historical),
             'vendors': viewer_profile.vendors(self.historical),
             'costumes': viewer_profile.get_costumebids(self.historical),
-            'review_items': bids_to_review,
+            'review_items': viewer_profile.bids_to_review(),
             'tickets': get_purchased_tickets(viewer_profile.user_object),
             'acceptance_states': acceptance_states,
             'admin_message': self.admin_message,

--- a/gbe/views/review_act_list_view.py
+++ b/gbe/views/review_act_list_view.py
@@ -5,12 +5,14 @@ from gbe.models import (
     ActBidEvaluation,
     EvaluationCategory,
     FlexibleEvaluation,
+    Profile,
     UserMessage,
 )
 from gbe.views import ReviewBidListView
-from django.db.models import Avg
+from django.db.models import Avg, Count
 from django.contrib import messages
 from gbetext import (
+    acceptance_states,
     apply_filter_msg,
     clear_filter_msg,
     no_filter_msg,
@@ -73,11 +75,34 @@ class ReviewActListView(ReviewBidListView):
 
     def get_context_dict(self):
         context = super(ReviewActListView, self).get_context_dict()
+        accept_metrics = {}
+        no_decision_count = 0
+        for accept_state in self.object_type.objects.filter(
+                b_conference=self.conference,
+                submitted=True).values('accepted').annotate(count=
+                Count("id")).order_by():
+            accept_metrics[acceptance_states[
+                accept_state['accepted']][1]] = accept_state['count']
+            if accept_state['accepted'] == 0:
+                no_decision_count = accept_state['count']
+
         context.update(
             {'vertical_columns': EvaluationCategory.objects.filter(
                 visible=True).order_by('category').values_list(
                 'category', flat=True),
-             'last_columns': ['Average', 'Action']})
+             'last_columns': ['Average', 'Action'],
+             'review_metrics':  {
+                'total_by_status': accept_metrics,
+                'total_by_reviewer': self.object_type.objects.filter(
+                    b_conference=self.conference,
+                    submitted=True,
+                    accepted=0).values(
+                    'actbidevaluation__evaluator__display_name'
+                    ).annotate(count=Count("id")).order_by(),
+                'total_no_decision': no_decision_count,
+                'act_reviewers': Profile.objects.filter(
+                    user_object__groups__name__in=self.reviewer_permissions)
+            }})
 
         if self.conference.status in ('upcoming', 'ongoing'):
             if self.filter_form is not None:

--- a/gbe/views/review_act_list_view.py
+++ b/gbe/views/review_act_list_view.py
@@ -79,8 +79,8 @@ class ReviewActListView(ReviewBidListView):
         no_decision_count = 0
         for accept_state in self.object_type.objects.filter(
                 b_conference=self.conference,
-                submitted=True).values('accepted').annotate(count=
-                Count("id")).order_by():
+                submitted=True).values('accepted').annotate(
+                count=Count("id")).order_by():
             accept_metrics[acceptance_states[
                 accept_state['accepted']][1]] = accept_state['count']
             if accept_state['accepted'] == 0:

--- a/tests/gbe/test_landing_page.py
+++ b/tests/gbe/test_landing_page.py
@@ -261,23 +261,15 @@ class TestIndex(TestCase):
         staff_profile = ProfileFactory(user_object__is_staff=True)
         grant_privilege(staff_profile, "Act Reviewers")
         login_as(staff_profile, self)
-        act = ActFactory(submitted=True,
-                         b_conference=self.current_conf)
-        url = reverse('home', urlconf='gbe.urls')
-        response = self.client.get(url)
-        self.assertContains(response, act.b_title)
-
-    def test_act_was_reviewed(self):
-        staff_profile = ProfileFactory(user_object__is_staff=True)
-        grant_privilege(staff_profile, "Act Reviewers")
-        login_as(staff_profile, self)
         reviewed_act = ActFactory(submitted=True,
                                   b_conference=self.current_conf)
         FlexibleEvaluationFactory(bid=reviewed_act,
                                   evaluator=staff_profile)
         url = reverse('home', urlconf='gbe.urls')
         response = self.client.get(url)
-        self.assertNotContains(response, reviewed_act.b_title)
+        self.assertContains(response, 'Act:  1 out of 2')
+        self.assertContains(response,
+                            reverse('act_review_list', urlconf='gbe.urls'))
 
     def test_classes_to_review(self):
         staff_profile = ProfileFactory(user_object__is_staff=True)
@@ -287,29 +279,29 @@ class TestIndex(TestCase):
                              b_conference=self.current_conf)
         url = reverse('home', urlconf='gbe.urls')
         response = self.client.get(url)
-        self.assertContains(response, klass.b_title)
+        self.assertContains(response, 'Class:  1 out of 1')
+        self.assertContains(response,
+                            reverse('class_review_list', urlconf='gbe.urls'))
 
     def test_vendors_to_review(self):
         staff_profile = ProfileFactory(user_object__is_staff=True)
         grant_privilege(staff_profile, "Vendor Reviewers")
         login_as(staff_profile, self)
-        vendor = VendorFactory(submitted=True,
-                               b_conference=self.current_conf)
         url = reverse('home', urlconf='gbe.urls')
         response = self.client.get(url)
-
-        self.assertContains(response, vendor.business.name)
+        self.assertContains(response, 'Vendor:  1 out of 1')
+        self.assertContains(response,
+                            reverse('vendor_review_list', urlconf='gbe.urls'))
 
     def test_costumes_to_review(self):
         staff_profile = ProfileFactory(user_object__is_staff=True)
         grant_privilege(staff_profile, "Costume Reviewers")
         login_as(staff_profile, self)
-        costume = CostumeFactory(submitted=True,
-                                 b_conference=self.current_conf)
         url = reverse('home', urlconf='gbe.urls')
         response = self.client.get(url)
-
-        self.assertContains(response, costume.b_title)
+        self.assertContains(response, 'Costume:  1 out of 1')
+        self.assertContains(response,
+                            reverse('costume_review_list', urlconf='gbe.urls'))
 
     def test_profile_image(self):
         set_image(self.performer)

--- a/tests/gbe/test_review_act_list.py
+++ b/tests/gbe/test_review_act_list.py
@@ -156,8 +156,13 @@ class TestReviewActList(TestCase):
         self.assertContains(response, 'gbe-table-row gbe-table-info')
         self.assertContains(response, self.metric_row % ("No Decision", 4))
         self.assertContains(response, self.metric_row % (
-            "Total Acts Pending Review",
-            1), html=True)
+            "Acts with no review at all",
+            3), html=True)
+        self.assertContains(
+            response,
+            ('<tr class="gbe-table-row"><td><b>Total Acts Pending Review' +
+             '</b></td><td><b>4</b></td></tr>'),
+            html=True)
 
     def test_review_act_has_average(self):
         ActBidEvaluationFactory(
@@ -179,7 +184,6 @@ class TestReviewActList(TestCase):
         response = self.client.get(
             self.url,
             data={'conf_slug': self.conference.conference_slug})
-        print(response.content)
         self.assertContains(response, str(3.67))
         self.assertContains(response, str(flex_eval.ranking))
         self.assertContains(response, "4.0", 2)


### PR DESCRIPTION
1 - summary on any reviewer's dashboard saying what they have or haven't reviewed yet.
2 - summary on the act review list page - accessible by a button click to open a hidden panel - available to anyone who accesses the page as there's no secret info in here.  Summary tells the counts of the states of all acts (ie accepted, rejected, no decision, etc) and how many reviews done by each reviewer, as well as how many acts have no review at all.

Gonna kick the tires a bit more, and verify code test coverage, but should be pretty close to done.