### PR TITLE
Gbe 542: Mail a submission confirmation to bidders

### DIFF
--- a/gbe/email/functions.py
+++ b/gbe/email/functions.py
@@ -133,17 +133,19 @@ def send_bid_state_change_mail(
         'status': acceptance_states[status][1],
         'site': site.domain,
         'site_name': site.name}
+    if context['status'] == "No Decision":
+        context['status'] = "Submitted"
     if casting:
         context['casting'] = casting
     if show:
         name = '%s %s - %s' % (
             bid_type.lower(),
-            acceptance_states[status][1].lower(),
+            context['status'].lower(),
             str(show).lower())
         action = 'Your %s has been cast in %s' % (
             bid_type,
             str(show))
-        if acceptance_states[status][1].lower() == 'wait list':
+        if context['status'].lower() == 'wait list':
             action = 'Your %s has been added to the wait list for %s' % (
                 bid_type,
                 str(show))
@@ -157,7 +159,7 @@ def send_bid_state_change_mail(
             args=[bid.pk],
             urlconf='gbe.urls')
     else:
-        name = '%s %s' % (bid_type, acceptance_states[status][1].lower())
+        name = '%s %s' % (bid_type, context['status'].lower())
         action = 'Your %s proposal has changed status to %s' % (
             bid_type,
             acceptance_states[status][1])
@@ -456,6 +458,17 @@ def get_user_email_templates(user):
                         'default_subject': subject % (show.title), }]
             elif priv != "volunteer" and state[1] == 'Awaiting Approval':
                 pass
+            elif state[1] == "No Decision":
+                # this is when the bidder submits.
+                template_set += [{
+                    'name': "%s submitted" % priv,
+                    'description': email_template_desc[state[1]] % priv,
+                    'category': priv,
+                    'default_base': "default_bid_status_change",
+                    'default_subject':
+                        'Your %s proposal has changed status to %s' % (
+                            priv,
+                            "Submitted"), }]
             else:
                 template_set += [{
                     'name': "%s %s" % (priv, state[1].lower()),

--- a/gbe/email/functions.py
+++ b/gbe/email/functions.py
@@ -162,7 +162,7 @@ def send_bid_state_change_mail(
         name = '%s %s' % (bid_type, context['status'].lower())
         action = 'Your %s proposal has changed status to %s' % (
             bid_type,
-            acceptance_states[status][1])
+            context['status'])
     template = get_or_create_template(
         name,
         "default_bid_status_change",

--- a/gbe/views/coordinate_act_view.py
+++ b/gbe/views/coordinate_act_view.py
@@ -11,6 +11,7 @@ from gbetext import (
     missing_profile_info,
     no_comp_msg,
 )
+from gbe.email.functions import send_bid_state_change_mail
 from gbe.ticketing_idd_interface import comp_act
 from gbe.models import UserMessage
 from django.contrib import messages
@@ -63,6 +64,12 @@ class CoordinateActView(PermissionRequiredMixin, MakeActView):
     def submit_bid(self, request):
         self.bid_object.submitted = True
         self.bid_object.save()
+        send_bid_state_change_mail(
+            str(self.bid_class.__name__).lower(),
+            self.bid_object.profile.contact_email,
+            self.bid_object.profile.get_badge_name(),
+            self.bid_object,
+            self.bid_object.accepted)
 
         redirect = reverse('act_review',
                            urlconf="gbe.urls",

--- a/gbe/views/make_bid_view.py
+++ b/gbe/views/make_bid_view.py
@@ -22,7 +22,10 @@ from gbe_logging import log_func
 from gbe.functions import (
     validate_profile,
 )
-from gbe.email.functions import notify_reviewers_on_bid_change
+from gbe.email.functions import (
+    notify_reviewers_on_bid_change,
+    send_bid_state_change_mail,
+)
 from gbetext import (
     no_login_msg,
     fee_instructions,
@@ -222,6 +225,12 @@ class MakeBidView(SubwayMapMixin, View):
             '%s Reviewers' % self.bid_type,
             reverse('%s_review' % self.bid_type.lower(),
                     urlconf='gbe.urls'))
+        send_bid_state_change_mail(
+            str(self.bid_class.__name__).lower(),
+            self.owner.contact_email,
+            self.owner.get_badge_name(),
+            self.bid_object,
+            self.bid_object.accepted)
 
     @never_cache
     @log_func

--- a/gbetext.py
+++ b/gbetext.py
@@ -339,8 +339,8 @@ calendar_for_event = {
 email_template_desc = {
     'submission notification': '''This email is sent to reviewers when a(n) \
     %s is submitted and ready for review.''',
-    'No Decision': '''This email is sent to a bidder when the coordinator \
-    sets the %s to the state "No Decision"''',
+    'No Decision': '''This email is sent to a bidder when the bidder has
+    submitted their %s''',
     'Reject': '''This email is sent to the bidder when the coordinator \
     rejects the %s''',
     'Wait List': '''This email is sent to the bidder when the %s is put on a \

--- a/tests/gbe/email/test_list_template.py
+++ b/tests/gbe/email/test_list_template.py
@@ -41,7 +41,7 @@ class TestTemplateList(TestCase):
         templates = ["volunteer accepted",
                      "volunteer awaiting approval",
                      "volunteer duplicate",
-                     "volunteer no decision",
+                     "volunteer submitted",
                      "volunteer reject",
                      "volunteer schedule update",
                      "volunteer changed schedule",
@@ -61,7 +61,7 @@ class TestTemplateList(TestCase):
 
         templates = ["act accepted - %s" % context.sched_event.title.lower(),
                      "act duplicate",
-                     "act no decision",
+                     "act submitted",
                      "act reject",
                      "act submission notification",
                      "act wait list - %s" % context.sched_event.title.lower(),
@@ -78,7 +78,7 @@ class TestTemplateList(TestCase):
 
             templates = ["%s accepted",
                          "%s duplicate",
-                         "%s no decision",
+                         "%s submitted",
                          "%s reject",
                          "%s submission notification",
                          "%s wait list",

--- a/tests/gbe/test_coordinate_act.py
+++ b/tests/gbe/test_coordinate_act.py
@@ -12,6 +12,7 @@ from tests.functions.gbe_functions import (
     grant_privilege,
     login_as,
     assert_alert_exists,
+    assert_right_mail_right_addresses,
 )
 from gbetext import (
     default_act_draft_msg,
@@ -109,6 +110,11 @@ class TestCoordinateAct(TestCase):
             ticket_item__ticketing_event__act_submission_event=True,
             ticket_item__ticketing_event__conference=self.current_conference
             ).exists())
+        assert_right_mail_right_addresses(
+            0,
+            1,
+            'Your act proposal has changed status to Submitted',
+            [just_made.performer.contact.contact_email])
 
     def test_act_submit_draft(self):
         tickets = setup_fees(self.current_conference, is_act=True)

--- a/tests/gbe/test_make_bid.py
+++ b/tests/gbe/test_make_bid.py
@@ -137,7 +137,9 @@ class TestMakeBid(TestCase):
         self.assertContains(response, self.conference.conference_name)
         self.assertContains(response, 'We will do our best to accommodate')
 
-    def test_class_posting_sends_mail_to_reviewers(self):
+    def test_class_posting_sends_mails(self):
+        # 1 mail to reviewers
+        # 1 mail to submitter as confirmation
         privileged_profile = ProfileFactory()
         grant_privilege(
             privileged_profile.user_object,
@@ -160,13 +162,18 @@ class TestMakeBid(TestCase):
         self.assertRedirects(response, reverse("home", urlconf='gbe.urls'))
         assert_right_mail_right_addresses(
             0,
-            1,
+            2,
             "bidder: %s, bid: %s" % (
                 str(self.performer.contact),
                 data['theclass-b_title']),
             [privileged_profile.contact_email],
             from_email="class@notify.com",
             from_name="Class Committee")
+        assert_right_mail_right_addresses(
+            1,
+            2,
+            'Your class proposal has changed status to Submitted',
+            [self.performer.contact.contact_email])
 
     def test_class_submit_has_message(self):
         '''class_bid, not submitting and no other problems,


### PR DESCRIPTION
- for any bidder of any type - sends a submission notification when they have successfully submitted their bid (act, class, vendor, etc).
- also when the act coordinator creates and submits and act for someone, that someone gets the "you've submitted an act"
- tweaked our "bid state change notification" templates so that "No Decision" is actually "Submitted" (NOTE to self - delete the "No decision" templates that exist, as they are now useless).  That lets the coordinator of the given bid type set the templates to whatever messaging they like.

Somewhat of an early PR write up, I'm still running through regressive testing.  But should be done soon with this.

