### PR TITLE
if there's no items, show nothing

### DIFF
--- a/gbe/templates/gbe/profile/incl_bids.tmpl
+++ b/gbe/templates/gbe/profile/incl_bids.tmpl
@@ -9,8 +9,6 @@
     	</li>
       {% endfor %}
     </ul>
-  {% else %}
-    {{ profile.display_name }} has no items to review
   {% endif %}
   </div>
 {% endif %}


### PR DESCRIPTION
fast fix to #551 

No tests cover this.
2 line template change (not even python code)

The mistake here is that 0 items to review comes up both when the reviewer has done all their work, AND when the user is NOT a reviewer.  The same thing (0 items to review) is true in the data given to the template.

I wrote that line with the reviewers in mind and failed to consider the normal masses.  It's an easy remove.