### PR TITLE
Gbe 562: fix 500 error when comping two acts in a row

### DIFF
--- a/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -9,7 +9,7 @@
       <a class="btn gbe-btn-primary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Comp Act Options</a>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
         <a class="dropdown-item" href="{% url 'gbe:act_coord_create' %}">Create & Comp Act</a>
-        <a class="dropdown-item" href="{% url 'ticketing:comp_ticket' %}?next={{ request.get_full_path }}">Send a Comp</a>
+        <a class="dropdown-item" href="{% url 'ticketing:comp_ticket' %}?next={{ request.META.PATH_INFO }}">Send a Comp</a>
       </div></div>{% endif %}
       <button class="btn gbe-btn-primary my-3" type="button" data-toggle="collapse" data-target="#actMetricCollapse" aria-expanded="false" aria-controls="actMetricCollapse">
       Act Review Metrics

--- a/gbe_utils/mixins/form_to_table_mixin.py
+++ b/gbe_utils/mixins/form_to_table_mixin.py
@@ -4,6 +4,9 @@ from gbe_utils.mixins import GbeFormMixin
 class FormToTableMixin(GbeFormMixin):
 
     def get_success_url(self):
+        next_url = self.request.GET.get('next', self.success_url)
+        if "?" in next_url:
+            next_url = next_url[:next_url.index("?")]
         return "%s?changed_id=%d" % (
-            self.request.GET.get('next', self.success_url),
+            next_url,
             self.object.pk)

--- a/tests/ticketing/test_create_transaction.py
+++ b/tests/ticketing/test_create_transaction.py
@@ -105,7 +105,7 @@ class TestIndex(TestCase):
         buyer = PurchaserFactory(matched_to_user=self.profile.user_object)
         login_as(self.privileged_user, self)
         response = self.client.post(
-            "%s?next=%s" % (self.url, act_review_url),
+            "%s?next=%s?changed_id=1176" % (self.url, act_review_url),
             data={'ticket_item': self.ticket.pk,
                   'profile': self.profile.pk},
             follow=True)
@@ -115,3 +115,4 @@ class TestIndex(TestCase):
             "%s?changed_id=%d" % (
                 act_review_url,
                 buyer.transaction_set.first().pk))
+        self.assertContains(response, "Act Proposals")


### PR DESCRIPTION
Problem came from not properly using the django template "path" variables - was sending the get request, when that was excessive.
Also from not cleaning the input properly in the create transaction view.

The two together created a malformed URL when the comp of the ticket was completed.

Fixed now.

Only wrote 1 test.  It turns out that there was no testing at all for the privileged functions for comping acts.  May want to tackle that later - but since the logic is in the template, prepared to leave alone for now.